### PR TITLE
move shift migration to after the data migration 

### DIFF
--- a/cabot/cabotapp/migrations/0019_auto__add_schedule__add_field_shift_schedule.py
+++ b/cabot/cabotapp/migrations/0019_auto__add_schedule__add_field_shift_schedule.py
@@ -26,11 +26,6 @@ class Migration(SchemaMigration):
         ))
         db.create_unique(m2m_table_name, ['instance_id', 'schedule_id'])
 
-        # Adding field 'Shift.schedule'
-        db.add_column(u'cabotapp_shift', 'schedule',
-                      self.gf('django.db.models.fields.related.ForeignKey')(to=orm['cabotapp.Schedule']),
-                      keep_default=False)
-
         # Adding M2M table for field schedules on 'Service'
         m2m_table_name = db.shorten_name(u'cabotapp_service_schedules')
         db.create_table(m2m_table_name, (
@@ -47,9 +42,6 @@ class Migration(SchemaMigration):
 
         # Removing M2M table for field schedules on 'Instance'
         db.delete_table(db.shorten_name(u'cabotapp_instance_schedules'))
-
-        # Deleting field 'Shift.schedule'
-        db.delete_column(u'cabotapp_shift', 'schedule_id')
 
         # Removing M2M table for field schedules on 'Service'
         db.delete_table(db.shorten_name(u'cabotapp_service_schedules'))
@@ -172,7 +164,6 @@ class Migration(SchemaMigration):
             'deleted': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
             'end': ('django.db.models.fields.DateTimeField', [], {}),
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
-            'schedule': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['cabotapp.Schedule']"}),
             'start': ('django.db.models.fields.DateTimeField', [], {}),
             'uid': ('django.db.models.fields.TextField', [], {}),
             'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']"})

--- a/cabot/cabotapp/migrations/0020_initial_schedule.py
+++ b/cabot/cabotapp/migrations/0020_initial_schedule.py
@@ -150,7 +150,6 @@ class Migration(DataMigration):
             'deleted': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
             'end': ('django.db.models.fields.DateTimeField', [], {}),
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
-            'schedule': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['cabotapp.Schedule']"}),
             'start': ('django.db.models.fields.DateTimeField', [], {}),
             'uid': ('django.db.models.fields.TextField', [], {}),
             'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']"})

--- a/cabot/cabotapp/migrations/0021_auto__del_field_userprofile_fallback_alert_user.py
+++ b/cabot/cabotapp/migrations/0021_auto__del_field_userprofile_fallback_alert_user.py
@@ -11,12 +11,19 @@ class Migration(SchemaMigration):
         # Deleting field 'UserProfile.fallback_alert_user'
         db.delete_column(u'cabotapp_userprofile', 'fallback_alert_user')
 
+        # Adding field 'Shift.schedule'
+        db.add_column(u'cabotapp_shift', 'schedule',
+                      self.gf('django.db.models.fields.related.ForeignKey')(default=1, to=orm['cabotapp.Schedule']),
+                      keep_default=False)
 
     def backwards(self, orm):
         # Adding field 'UserProfile.fallback_alert_user'
         db.add_column(u'cabotapp_userprofile', 'fallback_alert_user',
                       self.gf('django.db.models.fields.BooleanField')(default=False),
                       keep_default=False)
+
+        # Deleting field 'Shift.schedule'
+        db.delete_column(u'cabotapp_shift', 'schedule_id')
 
 
     models = {
@@ -136,7 +143,7 @@ class Migration(SchemaMigration):
             'deleted': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
             'end': ('django.db.models.fields.DateTimeField', [], {}),
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
-            'schedule': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['cabotapp.Schedule']"}),
+            'schedule': ('django.db.models.fields.related.ForeignKey', [], {'default': '1', 'to': u"orm['cabotapp.Schedule']"}),
             'start': ('django.db.models.fields.DateTimeField', [], {}),
             'uid': ('django.db.models.fields.TextField', [], {}),
             'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']"})

--- a/cabot/cabotapp/models.py
+++ b/cabot/cabotapp/models.py
@@ -1078,7 +1078,7 @@ class Shift(models.Model):
     user = models.ForeignKey(User)
     uid = models.TextField()
     deleted = models.BooleanField(default=False)
-    schedule = models.ForeignKey('Schedule')
+    schedule = models.ForeignKey('Schedule', default=1)
 
     def __unicode__(self):
         deleted = ''


### PR DESCRIPTION
because otherwise there's no value for a non-nullable column. add the default value back in