### PR TITLE
Index as part of ElasticsearchSource for parity with Grafana

### DIFF
--- a/cabot/metricsapp/api/elastic.py
+++ b/cabot/metricsapp/api/elastic.py
@@ -1,11 +1,11 @@
 from elasticsearch import Elasticsearch
 
 
-def create_es_client(urls):
+def create_es_client(urls, timeout):
     """
     Create an elasticsearch-py client
     :param urls: comma-separated string of urls
     :return: a new elasticsearch-py client
     """
     urls = [url.strip() for url in urls.split(',')]
-    return Elasticsearch(urls)
+    return Elasticsearch(urls, timeout=timeout)

--- a/cabot/metricsapp/api/elastic.py
+++ b/cabot/metricsapp/api/elastic.py
@@ -1,11 +1,10 @@
 from elasticsearch import Elasticsearch
 
 
-def create_es_client(urls):
+def create_es_client(url):
     """
     Create an elasticsearch-py client
-    :param urls: comma-separated string of urls
+    :param url: url string
     :return: a new elasticsearch-py client
     """
-    urls = [url.strip() for url in urls.split(',')]
-    return Elasticsearch(urls)
+    return Elasticsearch([url.strip()])

--- a/cabot/metricsapp/api/elastic.py
+++ b/cabot/metricsapp/api/elastic.py
@@ -1,10 +1,11 @@
 from elasticsearch import Elasticsearch
 
 
-def create_es_client(url):
+def create_es_client(urls):
     """
     Create an elasticsearch-py client
-    :param url: url string
+    :param urls: comma-separated string of urls
     :return: a new elasticsearch-py client
     """
-    return Elasticsearch([url.strip()])
+    urls = [url.strip() for url in urls.split(',')]
+    return Elasticsearch(urls)

--- a/cabot/metricsapp/forms/elastic.py
+++ b/cabot/metricsapp/forms/elastic.py
@@ -13,10 +13,11 @@ class ElasticsearchSourceForm(ModelForm):
     def clean_urls(self):
         """Make sure the input urls are valid Elasticsearch hosts."""
         input_urls = self.cleaned_data['urls']
+        timeout = self.cleaned_data['timeout']
 
         # Create an Elasticsearch test client and see if a health check for the instance succeeds
         try:
-            client = create_es_client(input_urls)
+            client = create_es_client(input_urls, timeout)
             ClusterClient(client).health()
             return input_urls
         except ConnectionError:

--- a/cabot/metricsapp/forms/elastic.py
+++ b/cabot/metricsapp/forms/elastic.py
@@ -10,14 +10,14 @@ class ElasticsearchSourceForm(ModelForm):
     class Meta:
         model = ElasticsearchSource
 
-    def clean_urls(self):
-        """Make sure the input urls are valid Elasticsearch hosts."""
-        input_urls = self.cleaned_data['urls']
+    def clean_url(self):
+        """Make sure the input url is a valid Elasticsearch hosts."""
+        url = self.cleaned_data['url']
 
         # Create an Elasticsearch test client and see if a health check for the instance succeeds
         try:
-            client = create_es_client(input_urls)
+            client = create_es_client(url)
             ClusterClient(client).health()
-            return input_urls
+            return url
         except ConnectionError:
             raise ValidationError('Invalid Elasticsearch host url(s).')

--- a/cabot/metricsapp/forms/elastic.py
+++ b/cabot/metricsapp/forms/elastic.py
@@ -10,14 +10,14 @@ class ElasticsearchSourceForm(ModelForm):
     class Meta:
         model = ElasticsearchSource
 
-    def clean_url(self):
-        """Make sure the input url is a valid Elasticsearch hosts."""
-        url = self.cleaned_data['url']
+    def clean_urls(self):
+        """Make sure the input urls are valid Elasticsearch hosts."""
+        input_urls = self.cleaned_data['urls']
 
         # Create an Elasticsearch test client and see if a health check for the instance succeeds
         try:
-            client = create_es_client(url)
+            client = create_es_client(input_urls)
             ClusterClient(client).health()
-            return url
+            return input_urls
         except ConnectionError:
             raise ValidationError('Invalid Elasticsearch host url(s).')

--- a/cabot/metricsapp/migrations/0001_initial.py
+++ b/cabot/metricsapp/migrations/0001_initial.py
@@ -72,7 +72,7 @@ class Migration(SchemaMigration):
             'cached_health': ('django.db.models.fields.TextField', [], {'null': 'True'}),
             'calculated_status': ('django.db.models.fields.CharField', [], {'default': "'passing'", 'max_length': '50', 'blank': 'True'}),
             'created_by': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']", 'null': 'True'}),
-            'debounce': ('django.db.models.fields.IntegerField', [], {'default': '0', 'null': 'True'}),
+            'retries': ('django.db.models.fields.IntegerField', [], {'default': '0', 'null': 'True'}),
             'frequency': ('django.db.models.fields.IntegerField', [], {'default': '5'}),
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
             'importance': ('django.db.models.fields.CharField', [], {'default': "'ERROR'", 'max_length': '30'}),

--- a/cabot/metricsapp/migrations/0002_auto__add_elasticsearchsource.py
+++ b/cabot/metricsapp/migrations/0002_auto__add_elasticsearchsource.py
@@ -11,7 +11,8 @@ class Migration(SchemaMigration):
         # Adding model 'ElasticsearchSource'
         db.create_table(u'metricsapp_elasticsearchsource', (
             (u'metricssourcebase_ptr', self.gf('django.db.models.fields.related.OneToOneField')(to=orm['metricsapp.MetricsSourceBase'], unique=True, primary_key=True)),
-            ('urls', self.gf('django.db.models.fields.TextField')(max_length=250)),
+            ('url', self.gf('django.db.models.fields.TextField')(max_length=150)),
+            ('index', self.gf('django.db.models.fields.TextField')(default='*', max_length=50)),
         ))
         db.send_create_signal('metricsapp', ['ElasticsearchSource'])
 
@@ -57,13 +58,13 @@ class Migration(SchemaMigration):
             'cached_health': ('django.db.models.fields.TextField', [], {'null': 'True'}),
             'calculated_status': ('django.db.models.fields.CharField', [], {'default': "'passing'", 'max_length': '50', 'blank': 'True'}),
             'created_by': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']", 'null': 'True'}),
-            'debounce': ('django.db.models.fields.IntegerField', [], {'default': '0', 'null': 'True'}),
             'frequency': ('django.db.models.fields.IntegerField', [], {'default': '5'}),
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
             'importance': ('django.db.models.fields.CharField', [], {'default': "'ERROR'", 'max_length': '30'}),
             'last_run': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
             'name': ('django.db.models.fields.TextField', [], {}),
-            'polymorphic_ctype': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'polymorphic_cabotapp.statuscheck_set'", 'null': 'True', 'to': u"orm['contenttypes.ContentType']"})
+            'polymorphic_ctype': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'polymorphic_cabotapp.statuscheck_set'", 'null': 'True', 'to': u"orm['contenttypes.ContentType']"}),
+            'retries': ('django.db.models.fields.IntegerField', [], {'default': '0', 'null': 'True'})
         },
         u'contenttypes.contenttype': {
             'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
@@ -74,8 +75,9 @@ class Migration(SchemaMigration):
         },
         'metricsapp.elasticsearchsource': {
             'Meta': {'object_name': 'ElasticsearchSource', '_ormbases': ['metricsapp.MetricsSourceBase']},
+            'index': ('django.db.models.fields.TextField', [], {'default': "'*'", 'max_length': '50'}),
             u'metricssourcebase_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['metricsapp.MetricsSourceBase']", 'unique': 'True', 'primary_key': 'True'}),
-            'urls': ('django.db.models.fields.TextField', [], {'max_length': '250'})
+            'url': ('django.db.models.fields.TextField', [], {'max_length': '150'})
         },
         'metricsapp.metricssourcebase': {
             'Meta': {'object_name': 'MetricsSourceBase'},

--- a/cabot/metricsapp/migrations/0002_auto__add_elasticsearchsource.py
+++ b/cabot/metricsapp/migrations/0002_auto__add_elasticsearchsource.py
@@ -13,6 +13,7 @@ class Migration(SchemaMigration):
             (u'metricssourcebase_ptr', self.gf('django.db.models.fields.related.OneToOneField')(to=orm['metricsapp.MetricsSourceBase'], unique=True, primary_key=True)),
             ('urls', self.gf('django.db.models.fields.TextField')(max_length=250)),
             ('index', self.gf('django.db.models.fields.TextField')(default='*', max_length=50)),
+            ('timeout', self.gf('django.db.models.fields.IntegerField')(default=60)),
         ))
         db.send_create_signal('metricsapp', ['ElasticsearchSource'])
 
@@ -77,6 +78,7 @@ class Migration(SchemaMigration):
             'Meta': {'object_name': 'ElasticsearchSource', '_ormbases': ['metricsapp.MetricsSourceBase']},
             'index': ('django.db.models.fields.TextField', [], {'default': "'*'", 'max_length': '50'}),
             u'metricssourcebase_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['metricsapp.MetricsSourceBase']", 'unique': 'True', 'primary_key': 'True'}),
+            'timeout': ('django.db.models.fields.IntegerField', [], {'default': '60'}),
             'urls': ('django.db.models.fields.TextField', [], {'max_length': '250'})
         },
         'metricsapp.metricssourcebase': {

--- a/cabot/metricsapp/migrations/0002_auto__add_elasticsearchsource.py
+++ b/cabot/metricsapp/migrations/0002_auto__add_elasticsearchsource.py
@@ -11,7 +11,7 @@ class Migration(SchemaMigration):
         # Adding model 'ElasticsearchSource'
         db.create_table(u'metricsapp_elasticsearchsource', (
             (u'metricssourcebase_ptr', self.gf('django.db.models.fields.related.OneToOneField')(to=orm['metricsapp.MetricsSourceBase'], unique=True, primary_key=True)),
-            ('url', self.gf('django.db.models.fields.TextField')(max_length=150)),
+            ('urls', self.gf('django.db.models.fields.TextField')(max_length=250)),
             ('index', self.gf('django.db.models.fields.TextField')(default='*', max_length=50)),
         ))
         db.send_create_signal('metricsapp', ['ElasticsearchSource'])
@@ -77,7 +77,7 @@ class Migration(SchemaMigration):
             'Meta': {'object_name': 'ElasticsearchSource', '_ormbases': ['metricsapp.MetricsSourceBase']},
             'index': ('django.db.models.fields.TextField', [], {'default': "'*'", 'max_length': '50'}),
             u'metricssourcebase_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['metricsapp.MetricsSourceBase']", 'unique': 'True', 'primary_key': 'True'}),
-            'url': ('django.db.models.fields.TextField', [], {'max_length': '150'})
+            'urls': ('django.db.models.fields.TextField', [], {'max_length': '250'})
         },
         'metricsapp.metricssourcebase': {
             'Meta': {'object_name': 'MetricsSourceBase'},

--- a/cabot/metricsapp/models/elastic.py
+++ b/cabot/metricsapp/models/elastic.py
@@ -10,11 +10,15 @@ class ElasticsearchSource(MetricsSourceBase):
     def __str__(self):
         return self.name
 
-    urls = models.TextField(
-        max_length=250,
+    url = models.TextField(
+        max_length=150,
         null=False,
-        help_text='Comma-separated list of Elasticsearch hosts. '
-                  'Format: "localhost" or "https://user:secret@localhost:443."'
+        help_text='The Elasticsearch host. Format: "localhost" or "https://user:secret@localhost:443."'
+    )
+    index = models.TextField(
+        max_length=50,
+        default='*',
+        help_text='Elasticsearch index name. Can include wildcards (*)',
     )
 
     _client = None
@@ -27,4 +31,4 @@ class ElasticsearchSource(MetricsSourceBase):
         """
         if self._client:
             return self._client
-        return create_es_client(self.urls)
+        return create_es_client(self.url)

--- a/cabot/metricsapp/models/elastic.py
+++ b/cabot/metricsapp/models/elastic.py
@@ -10,10 +10,11 @@ class ElasticsearchSource(MetricsSourceBase):
     def __str__(self):
         return self.name
 
-    url = models.TextField(
-        max_length=150,
+    urls = models.TextField(
+        max_length=250,
         null=False,
-        help_text='The Elasticsearch host. Format: "localhost" or "https://user:secret@localhost:443."'
+        help_text='Comma-separated list of Elasticsearch hosts. '
+                  'Format: "localhost" or "https://user:secret@localhost:443."'
     )
     index = models.TextField(
         max_length=50,
@@ -31,4 +32,4 @@ class ElasticsearchSource(MetricsSourceBase):
         """
         if self._client:
             return self._client
-        return create_es_client(self.url)
+        return create_es_client(self.urls)

--- a/cabot/metricsapp/models/elastic.py
+++ b/cabot/metricsapp/models/elastic.py
@@ -21,6 +21,10 @@ class ElasticsearchSource(MetricsSourceBase):
         default='*',
         help_text='Elasticsearch index name. Can include wildcards (*)',
     )
+    timeout = models.IntegerField(
+        default=60,
+        help_text='Timeout for queries to this index.'
+    )
 
     _client = None
 
@@ -32,4 +36,4 @@ class ElasticsearchSource(MetricsSourceBase):
         """
         if self._client:
             return self._client
-        return create_es_client(self.urls)
+        return create_es_client(self.urls, self.timeout)

--- a/cabot/metricsapp/tests/test_elasticsearch.py
+++ b/cabot/metricsapp/tests/test_elasticsearch.py
@@ -6,7 +6,7 @@ class TestElasticsearchSource(TestCase):
     def setUp(self):
         self.es_source = ElasticsearchSource.objects.create(
             name='elastigirl',
-            url='localhost',
+            urls='localhost',
             index='i'
         )
 
@@ -14,11 +14,19 @@ class TestElasticsearchSource(TestCase):
         client = self.es_source.client
         self.assertIn('localhost', repr(client))
 
-    def test_client_whitespace(self):
-        """Whitespace should be stripped from the url"""
-        self.es_source.url = '\n\nlocalhost     '
+    def test_multiple_clients(self):
+        self.es_source.urls = 'localhost,127.0.0.1'
         self.es_source.save()
         client = self.es_source.client
         self.assertIn('localhost', repr(client))
+        self.assertIn('127.0.0.1', repr(client))
+
+    def test_client_whitespace(self):
+        """Whitespace should be stripped from the urls"""
+        self.es_source.urls = '\nlocalhost,       globalhost'
+        self.es_source.save()
+        client = self.es_source.client
+        self.assertIn('localhost', repr(client))
+        self.assertIn('globalhost', repr(client))
         self.assertNotIn('\nlocalhost', repr(client))
-        self.assertNotIn('localhost ', repr(client))
+        self.assertNotIn(' globalhost', repr(client))

--- a/cabot/metricsapp/tests/test_elasticsearch.py
+++ b/cabot/metricsapp/tests/test_elasticsearch.py
@@ -6,26 +6,19 @@ class TestElasticsearchSource(TestCase):
     def setUp(self):
         self.es_source = ElasticsearchSource.objects.create(
             name='elastigirl',
-            urls='localhost'
+            url='localhost',
+            index='i'
         )
 
     def test_client(self):
         client = self.es_source.client
         self.assertIn('localhost', repr(client))
 
-    def test_multiple_clients(self):
-        self.es_source.urls = 'localhost,127.0.0.1'
-        self.es_source.save()
-        client = self.es_source.client
-        self.assertIn('localhost', repr(client))
-        self.assertIn('127.0.0.1', repr(client))
-
     def test_client_whitespace(self):
-        """Whitespace should be stripped from the urls"""
-        self.es_source.urls = '\nlocalhost,       globalhost'
+        """Whitespace should be stripped from the url"""
+        self.es_source.url = '\n\nlocalhost     '
         self.es_source.save()
         client = self.es_source.client
         self.assertIn('localhost', repr(client))
-        self.assertIn('globalhost', repr(client))
         self.assertNotIn('\nlocalhost', repr(client))
-        self.assertNotIn(' globalhost', repr(client))
+        self.assertNotIn('localhost ', repr(client))


### PR DESCRIPTION
- Add index to ElasticsearchSource

since this is how Grafana Elasticsearch data sources work. 

I just edited the migration since it's not deployed on prod yet and it seems better to consolidate migrations, lmk if I should create a new one instead. 