### PR TITLE
Infra 3710 grafana

### DIFF
--- a/cabot/metricsapp/admin.py
+++ b/cabot/metricsapp/admin.py
@@ -1,6 +1,8 @@
 from django.contrib import admin
-from cabot.metricsapp.models import ElasticsearchSource, ElasticsearchStatusCheck
-from cabot.metricsapp.forms import ElasticsearchSourceForm, ElasticsearchStatusCheckForm
+from cabot.metricsapp.models import ElasticsearchSource, ElasticsearchStatusCheck, \
+    GrafanaDataSource, GrafanaInstance
+from cabot.metricsapp.forms import ElasticsearchSourceForm, ElasticsearchStatusCheckForm, \
+    GrafanaDataSourceAdminForm, GrafanaInstanceAdminForm
 
 
 class ElasticsearchSourceAdmin(admin.ModelAdmin):
@@ -11,5 +13,15 @@ class ElasticsearchStatusCheckAdmin(admin.ModelAdmin):
     form = ElasticsearchStatusCheckForm
 
 
+class GrafanaInstanceAdmin(admin.ModelAdmin):
+    form = GrafanaInstanceAdminForm
+
+
+class GrafanaDataSourceAdmin(admin.ModelAdmin):
+    form = GrafanaDataSourceAdminForm
+
+
 admin.site.register(ElasticsearchSource, ElasticsearchSourceAdmin)
 admin.site.register(ElasticsearchStatusCheck, ElasticsearchStatusCheckAdmin)
+admin.site.register(GrafanaDataSource, GrafanaDataSourceAdmin)
+admin.site.register(GrafanaInstance, GrafanaInstanceAdmin)

--- a/cabot/metricsapp/api/__init__.py
+++ b/cabot/metricsapp/api/__init__.py
@@ -1,3 +1,7 @@
 from .base import run_metrics_check
 from .elastic import create_es_client, validate_query
-from .elastic_grafana import build_query, template_response, create_elasticsearch_templating_dict
+from .grafana_elastic import build_query, template_response, create_elasticsearch_templating_dict, \
+    get_es_status_check_fields
+from .grafana import get_dashboards, get_dashboard_choices, get_dashboard_info, \
+    get_panel_choices, get_series_choices, template_response, create_generic_templating_dict, \
+    get_status_check_fields

--- a/cabot/metricsapp/api/grafana.py
+++ b/cabot/metricsapp/api/grafana.py
@@ -1,0 +1,167 @@
+import json
+import logging
+import requests
+from django.core.exceptions import ValidationError
+from pytimeparse import parse
+
+
+logger = logging.getLogger(__name__)
+
+
+def get_dashboards(grafana_instance):
+    """
+    Get information about all Grafana dashboards from the API
+    :param grafana_instance: GrafanaInstance object corresponding to the Grafana site
+    :return: api response containing dashboard id, title, uri, etc.
+    """
+    response = grafana_instance.get_request('api/search')
+
+    try:
+        response.raise_for_status()
+        return response.json()
+    except requests.exceptions.HTTPError as e:
+        logger.exception('Request to {} failed with error {}'.format(grafana_instance.url, e))
+        raise ValidationError('Request to Grafana API failed.')
+
+
+def get_dashboard_choices(api_response):
+    """
+    Given a response from the Grafana API, find a list of dashboard name choices
+    :param api_response: response data from the Grafana API
+    :return: list of dashboard URIs and names
+    """
+    return [(dash['uri'], dash['title']) for dash in api_response]
+
+
+def get_dashboard_info(grafana_instance, dashboard_uri):
+    """
+    Get information about a Grafana dashboard
+    :param grafana_instance: GrafanaInstance object corresponding to the Grafana site
+    :param dashboard_uri: dashboard part of the url
+    :return: api response containing creator information and panel information
+    """
+    response = grafana_instance.get_request('api/dashboards/{}'.format(dashboard_uri))
+
+    try:
+        response.raise_for_status()
+        return response.json()
+    except requests.exceptions.HTTPError as e:
+        logger.exception('Request to {} for dashboard {} failed with error {}'.format(grafana_instance.url,
+                                                                                      dashboard_uri, e))
+        raise ValidationError('Request to Grafana API failed.')
+
+
+def get_panel_choices(dashboard_info, templating_dict):
+    """
+    Get a list of graph panel choices (names and data)
+    :param dashboard_info: Dashboard data from the Grafana API
+    :param templating_dict: dictionary of {template_name, template_value}
+    :return list of ({panel_id, datasource, panel_info}, name) tuples for panels
+    """
+    panels = []
+    for row in dashboard_info['dashboard']['rows']:
+        for panel in filter(lambda panel: panel['type'] == 'graph', row['panels']):
+            datasource = panel.get('datasource')
+            # default datasource is not listed in the API response
+            if datasource is None:
+                datasource = 'default'
+
+            title = template_response(panel['title'], templating_dict)
+            panels.append((dict(panel_id=panel['id'], datasource=datasource, panel_info=panel), title))
+
+    return panels
+
+
+def get_series_choices(panel_info, templating_dict):
+    """
+    Get a list of the series for the panel with the input id
+    :param panel_id: the id of the selected panel
+    :param templating_dict: dictionary of {template_name, template_value}
+    :return list of (id, series_info) tuples from the series in the panel
+    """
+    templated_panel = template_response(panel_info, templating_dict)
+    out = []
+    # Will display all fields in a json blob (not pretty but it works)
+    for series in filter(lambda s: s.get('hide') is not True, templated_panel['targets']):
+        # ref_id, datasource type, and timefield aren't useful info to display
+        ref_id = series.pop('refId')
+        series.pop('dsType')
+        series.pop('timeField')
+        out.append((ref_id, json.dumps(series)))
+    return out
+
+
+def template_response(data, templating_dict):
+    """
+    Change data from the Grafana dashboard API response
+    based on the dashboard templates
+    :param data: Data from the Grafana dashboard API
+    :param templating_dict: dictionary of {template_name, template _value}
+    :return: panel_info with all templating values filled in
+    """
+    data = json.dumps(data)
+    # Loop through all the templates and replace them if they're used in this panel
+    for template in templating_dict:
+        data = data.replace('${}'.format(template), templating_dict[template])
+    return json.loads(data)
+
+
+def create_generic_templating_dict(dashboard_info):
+    """
+    Generic templating dictionary: name just maps to value
+    :param dashboard_info: Grafana dashboard API response
+    :return: dict of {"name": "value"}
+    """
+    templates = {}
+
+    templating_info = dashboard_info['dashboard']['templating']
+    for template in filter(lambda template: template.get('current'), templating_info['list']):
+        value = template['current']['value']
+        name = template['name']
+
+        if isinstance(value, list):
+            value = ', '.join(value)
+        elif value == '$__auto_interval':
+            value = 'auto'
+
+        templates[name] = value
+
+    return templates
+
+
+def get_status_check_fields(dashboard_info, panel_info, grafana_instance_id, datasource, templating_dict):
+    """
+    Given dashboard, panel, instance, and datasource info, find the fields for a generic status check
+    :param dashboard_info: Grafana API dashboard info
+    :param panel_info: Grafana API panel info
+    :param grafana_instance_id: ID of the Grafana instance used
+    :param templating_dict: dictionary of {template_name, template _value}
+    :return: dictionary containing StatusCheck field names and values
+    """
+    fields = {}
+
+    fields['name'] = template_response(panel_info['title'], templating_dict)
+    fields['source_info'] = dict(grafana_source_name=datasource,
+                                 grafana_instance_id=grafana_instance_id)
+
+    # Earliest time should be formatted "now-3h", all other formats will be ignored
+    time_from = dashboard_info['dashboard']['time']['from'].split('-')
+    if len(time_from) == 2:
+        timestring = str(time_from[1])
+        # pytimeparse.parse returns seconds, we want minutes
+        fields['time_range'] = parse(timestring) / 60
+
+    thresholds = panel_info['thresholds']
+    for threshold in thresholds:
+        if threshold['op'] == 'gt':
+            fields['check_type'] = '>'
+        else:
+            fields['check_type'] = '<'
+
+        color = threshold['colorMode']
+        if color == 'warning':
+            fields['warning_value'] = float(threshold['value'])
+        elif color == 'critical':
+            fields['high_alert_value'] = float(threshold['value'])
+
+    return fields

--- a/cabot/metricsapp/api/grafana_elastic.py
+++ b/cabot/metricsapp/api/grafana_elastic.py
@@ -1,9 +1,10 @@
 import logging
-import json
+from collections import defaultdict
 from elasticsearch_dsl import Search, A
 from elasticsearch_dsl.query import Range
 from django.core.exceptions import ValidationError
 from cabot.metricsapp.defs import ES_SUPPORTED_METRICS, ES_TIME_RANGE, ES_DEFAULT_INTERVAL
+from .grafana import template_response
 
 
 logger = logging.getLogger(__name__)
@@ -114,25 +115,15 @@ def build_query(series, min_time=ES_TIME_RANGE, default_interval=ES_DEFAULT_INTE
     :param default_interval: default for the group by interval
     :return: Elasticsearch json query
     """
-    search = Search().query('query_string', query=series['query'], analyze_wildcard=True) \
+    query = series.get('query')
+    # If there's no specified query, query for everything
+    if query is None:
+        query = '*'
+
+    search = Search().query('query_string', query=query, analyze_wildcard=True) \
         .query(Range(** {series['timeField']: {'gte': min_time}}))
     _add_aggs(search.aggs, series, min_time, default_interval)
     return search.to_dict()
-
-
-def template_response(data, templating_dict):
-    """
-    Change the panel info from the Grafana dashboard API response
-    based on the dashboard templates
-    :param data: any string portion of the response from the Grafana API
-    :param templating_info: dictionary of {template_name, output_value}
-    :return: panel_info with all templating values filled in
-    """
-    data = json.dumps(data)
-    # Loop through all the templates and replace them if they're used in this panel
-    for name, value in templating_dict.iteritems():
-        data = data.replace('${}'.format(name), value)
-    return json.loads(data)
 
 
 def create_elasticsearch_templating_dict(dashboard_info):
@@ -168,3 +159,36 @@ def create_elasticsearch_templating_dict(dashboard_info):
             templates[template_name] = template_value
 
     return templates
+
+
+def get_es_status_check_fields(dashboard_info, panel_info, series_list):
+    """
+    Get the fields necessary to create an ElasticsearchStatusCheck (that aren't in a generic
+    MetricsStatusCheck).
+    :param dashboard_info: all info for a dashboard from the Grafana API
+    :param panel_info: info about the panel we're alerting off of from the Grafana API
+    :param series_list: the series the user selected to use
+    :return dictionary of the required ElasticsearchStatusCheck fields (queries)
+    """
+    fields = defaultdict(list)
+
+    templating_dict = create_elasticsearch_templating_dict(dashboard_info)
+    series_list = [s for s in panel_info['targets'] if s['refId'] in series_list]
+    min_time = dashboard_info['dashboard']['time']['from']
+    default_interval = panel_info.get('interval')
+
+    if default_interval is not None:
+        # interval can be in format (>1h, <10m, etc.). Get rid of symbols
+        templated_interval = str(template_response(default_interval, templating_dict))
+        default_interval = filter(str.isalnum, templated_interval)
+
+    for series in series_list:
+        templated_series = template_response(series, templating_dict)
+        if default_interval is not None and default_interval != 'auto':
+            query = build_query(templated_series, min_time=min_time, default_interval=default_interval)
+        else:
+            query = build_query(templated_series, min_time=min_time)
+
+        fields['queries'].append(query)
+
+    return fields

--- a/cabot/metricsapp/forms/__init__.py
+++ b/cabot/metricsapp/forms/__init__.py
@@ -1,2 +1,4 @@
-from .elastic import *
-
+from .elastic import ElasticsearchSourceForm, ElasticsearchStatusCheckForm
+from .grafana_elastic import GrafanaElasticsearchStatusCheckForm
+from .grafana import GrafanaInstanceAdminForm, GrafanaDataSourceAdminForm, GrafanaInstanceForm, GrafanaDashboardForm, \
+    GrafanaPanelForm, GrafanaSeriesForm, GrafanaStatusCheckForm

--- a/cabot/metricsapp/forms/grafana.py
+++ b/cabot/metricsapp/forms/grafana.py
@@ -1,0 +1,118 @@
+from django import forms
+from cabot.cabotapp.views import StatusCheckForm
+from cabot.metricsapp.models import GrafanaInstance, GrafanaDataSource
+
+
+# Model forms for admin site
+class GrafanaInstanceAdminForm(forms.ModelForm):
+    class Meta:
+        model = GrafanaInstance
+
+
+class GrafanaDataSourceAdminForm(forms.ModelForm):
+    class Meta:
+        model = GrafanaDataSource
+
+
+# Forms for selecting Grafana instance, dashboard, panel, etc.
+class GrafanaInstanceForm(forms.Form):
+    """Select a Grafana instance to use for a status check"""
+    grafana_instance = forms.ModelChoiceField(
+        queryset=GrafanaInstance.objects.all(),
+        initial=1,
+        help_text='Grafana site instance to select a dashboard from.'
+    )
+
+
+class GrafanaDashboardForm(forms.Form):
+    """Select a Grafana dashboard to use for a status check"""
+    def __init__(self, *args, **kwargs):
+        dashboards = kwargs.pop('dashboards')
+        super(GrafanaDashboardForm, self).__init__(*args, **kwargs)
+
+        self.fields['dashboard'] = forms.ChoiceField(
+            choices=dashboards,
+            help_text='Grafana dashboard to use for the check.'
+        )
+
+
+class GrafanaPanelForm(forms.Form):
+    """Select a Grafana panel to use for a status check"""
+    def __init__(self, *args, **kwargs):
+        panels = kwargs.pop('panels')
+        super(GrafanaPanelForm, self).__init__(*args, **kwargs)
+
+        self.fields['panel'] = forms.ChoiceField(
+            choices=panels,
+            help_text='Grafana panel to use for the check.'
+        )
+
+    def clean_panel(self):
+        """Make sure the data source for the panel is supported"""
+        panel = eval(self.cleaned_data['panel'])
+        datasource = panel['datasource']
+
+        try:
+            GrafanaDataSource.objects.get(grafana_source_name=datasource)
+        except GrafanaDataSource.DoesNotExist:
+            raise forms.ValidationError('No matching data source for {}.'.format(datasource))
+
+        return panel
+
+
+class GrafanaSeriesForm(forms.Form):
+    """Select the series to use for a status check"""
+    def __init__(self, *args, **kwargs):
+        series = kwargs.pop('series')
+        super(GrafanaSeriesForm, self).__init__(*args, **kwargs)
+
+        self.fields['series'] = forms.MultipleChoiceField(
+            choices=series,
+            widget=forms.CheckboxSelectMultiple,
+            help_text='Data series to use in the check.'
+        )
+
+    def clean_series(self):
+        """Make sure at least one series is selected."""
+        series = self.cleaned_data.get('series')
+        if not series:
+            raise forms.ValidationError('At least one series must be selected.')
+
+        return series
+
+
+class GrafanaStatusCheckForm(StatusCheckForm):
+    """Generic form for creating a status check. Other metrics sources will subclass this."""
+    def __init__(self, *args, **kwargs):
+        fields = kwargs.pop('fields')
+        super(GrafanaStatusCheckForm, self).__init__(*args, **kwargs)
+
+        self.fields['name'].initial = fields['name']
+
+        # Hide name field so users can't edit it.
+        self.fields['name'].widget = forms.TextInput(attrs=dict(readonly='readonly', style='width:50%'))
+        self.fields['name'].help_text = None
+
+        # Time range, check_type, and thresholds are editable.
+        for field_name in ['time_range', 'check_type', 'warning_value', 'high_alert_value']:
+            field_value = fields.get(field_name)
+            if field_value is not None:
+                self.fields[field_name].initial = field_value
+                self.fields[field_name].help_text += ' Autofilled from the Grafana dashboard.'
+
+        # Store fields for the source, which will be set in save()
+        source_info = fields['source_info']
+        self.grafana_source_name = source_info['grafana_source_name']
+        self.grafana_instance_id = source_info['grafana_instance_id']
+
+    def save(self):
+        # set the MetricsSourceBase here so we don't have to display it
+        model = super(GrafanaStatusCheckForm, self).save(commit=False)
+
+        model.source = GrafanaDataSource.objects.get(
+            grafana_source_name=self.grafana_source_name,
+            grafana_instance_id=self.grafana_instance_id,
+        ).metrics_source_base
+
+        model.save()
+        return model

--- a/cabot/metricsapp/forms/grafana_elastic.py
+++ b/cabot/metricsapp/forms/grafana_elastic.py
@@ -1,0 +1,31 @@
+from django import forms
+import json
+from .grafana import GrafanaStatusCheckForm
+from cabot.metricsapp.models import ElasticsearchStatusCheck
+
+
+class GrafanaElasticsearchStatusCheckForm(GrafanaStatusCheckForm):
+    class Meta:
+        model = ElasticsearchStatusCheck
+        fields = [
+            'name',
+            'queries',
+            'active',
+            'check_type',
+            'warning_value',
+            'high_alert_importance',
+            'high_alert_value',
+            'frequency',
+            'retries',
+            'time_range',
+        ]
+
+    def __init__(self, *args, **kwargs):
+        es_fields = kwargs.pop('es_fields')
+        super(GrafanaElasticsearchStatusCheckForm, self).__init__(*args, **kwargs)
+
+        self.fields['queries'].initial = json.dumps(es_fields['queries'])
+        # Hide queries so users can't edit them
+        self.fields['queries'].widget = forms.Textarea(attrs=dict(readonly='readonly',
+                                                                  style='width:100%'))
+        self.fields['queries'].help_text = None

--- a/cabot/metricsapp/migrations/0004_auto__add_grafanainstance__add_grafanadatasource.py
+++ b/cabot/metricsapp/migrations/0004_auto__add_grafanainstance__add_grafanadatasource.py
@@ -1,0 +1,134 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding model 'GrafanaInstance'
+        db.create_table(u'metricsapp_grafanainstance', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('name', self.gf('django.db.models.fields.CharField')(unique=True, max_length=30)),
+            ('url', self.gf('django.db.models.fields.CharField')(max_length=100)),
+            ('api_key', self.gf('django.db.models.fields.CharField')(max_length=100)),
+        ))
+        db.send_create_signal('metricsapp', ['GrafanaInstance'])
+
+        # Adding model 'GrafanaDataSource'
+        db.create_table(u'metricsapp_grafanadatasource', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('grafana_source_name', self.gf('django.db.models.fields.CharField')(max_length=30)),
+            ('grafana_instance', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['metricsapp.GrafanaInstance'])),
+            ('metrics_source_base', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['metricsapp.MetricsSourceBase'])),
+        ))
+        db.send_create_signal('metricsapp', ['GrafanaDataSource'])
+
+
+    def backwards(self, orm):
+        # Deleting model 'GrafanaInstance'
+        db.delete_table(u'metricsapp_grafanainstance')
+
+        # Deleting model 'GrafanaDataSource'
+        db.delete_table(u'metricsapp_grafanadatasource')
+
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'cabotapp.statuscheck': {
+            'Meta': {'ordering': "['name']", 'object_name': 'StatusCheck'},
+            'active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'cached_health': ('django.db.models.fields.TextField', [], {'null': 'True'}),
+            'calculated_status': ('django.db.models.fields.CharField', [], {'default': "'passing'", 'max_length': '50', 'blank': 'True'}),
+            'created_by': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']", 'null': 'True'}),
+            'frequency': ('django.db.models.fields.IntegerField', [], {'default': '5'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'importance': ('django.db.models.fields.CharField', [], {'default': "'ERROR'", 'max_length': '30'}),
+            'last_run': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            'name': ('django.db.models.fields.TextField', [], {}),
+            'polymorphic_ctype': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'polymorphic_cabotapp.statuscheck_set'", 'null': 'True', 'to': u"orm['contenttypes.ContentType']"}),
+            'retries': ('django.db.models.fields.IntegerField', [], {'default': '0', 'null': 'True'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'metricsapp.elasticsearchsource': {
+            'Meta': {'object_name': 'ElasticsearchSource', '_ormbases': ['metricsapp.MetricsSourceBase']},
+            'index': ('django.db.models.fields.TextField', [], {'default': "'*'", 'max_length': '50'}),
+            'max_concurrent_searches': ('django.db.models.fields.IntegerField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            u'metricssourcebase_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['metricsapp.MetricsSourceBase']", 'unique': 'True', 'primary_key': 'True'}),
+            'timeout': ('django.db.models.fields.IntegerField', [], {'default': '20'}),
+            'urls': ('django.db.models.fields.TextField', [], {'max_length': '250'})
+        },
+        'metricsapp.elasticsearchstatuscheck': {
+            'Meta': {'ordering': "['name']", 'object_name': 'ElasticsearchStatusCheck', '_ormbases': ['metricsapp.MetricsStatusCheckBase']},
+            u'metricsstatuscheckbase_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['metricsapp.MetricsStatusCheckBase']", 'unique': 'True', 'primary_key': 'True'}),
+            'queries': ('django.db.models.fields.TextField', [], {'max_length': '10000'})
+        },
+        'metricsapp.grafanadatasource': {
+            'Meta': {'object_name': 'GrafanaDataSource'},
+            'grafana_instance': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['metricsapp.GrafanaInstance']"}),
+            'grafana_source_name': ('django.db.models.fields.CharField', [], {'max_length': '30'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'metrics_source_base': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['metricsapp.MetricsSourceBase']"})
+        },
+        'metricsapp.grafanainstance': {
+            'Meta': {'object_name': 'GrafanaInstance'},
+            'api_key': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'}),
+            'sources': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['metricsapp.MetricsSourceBase']", 'through': "orm['metricsapp.GrafanaDataSource']", 'symmetrical': 'False'}),
+            'url': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'metricsapp.metricssourcebase': {
+            'Meta': {'object_name': 'MetricsSourceBase'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'metricsapp.metricsstatuscheckbase': {
+            'Meta': {'ordering': "['name']", 'object_name': 'MetricsStatusCheckBase', '_ormbases': [u'cabotapp.StatusCheck']},
+            'check_type': ('django.db.models.fields.CharField', [], {'max_length': '30'}),
+            'high_alert_importance': ('django.db.models.fields.CharField', [], {'default': "'ERROR'", 'max_length': '30'}),
+            'high_alert_value': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'source': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['metricsapp.MetricsSourceBase']"}),
+            u'statuscheck_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['cabotapp.StatusCheck']", 'unique': 'True', 'primary_key': 'True'}),
+            'time_range': ('django.db.models.fields.IntegerField', [], {'default': '30'}),
+            'warning_value': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['metricsapp']

--- a/cabot/metricsapp/models/__init__.py
+++ b/cabot/metricsapp/models/__init__.py
@@ -1,2 +1,3 @@
-from .base import *
-from .elastic import *
+from .base import MetricsSourceBase, MetricsStatusCheckBase
+from .elastic import ElasticsearchSource, ElasticsearchStatusCheck
+from .grafana import GrafanaInstance, GrafanaDataSource

--- a/cabot/metricsapp/models/base.py
+++ b/cabot/metricsapp/models/base.py
@@ -34,7 +34,8 @@ class MetricsStatusCheckBase(StatusCheck):
     warning_value = models.FloatField(
         null=True,
         blank=True,
-        help_text='If this expression evaluates to False, the check will fail with a warning.'
+        help_text='If this expression evaluates to False, the check will fail with a warning. Checks may have '
+                  'both warning and high alert values, or only one.'
     )
     high_alert_importance = models.CharField(
         max_length=30,

--- a/cabot/metricsapp/models/elastic.py
+++ b/cabot/metricsapp/models/elastic.py
@@ -31,9 +31,9 @@ class ElasticsearchSource(MetricsSourceBase):
         max_length=50,
         default='*',
         help_text=escape('Elasticsearch index name. Can include wildcards ("*") or date math expressions '
-                  '("<static_name{date_math_expr{date_format|time_zone}}\>"). For example, an index could be '
-                  '"<metrics-{now/d}>,<metrics-{now/d-1d}>", resolving to "metrics-yyyy-mm-dd,metrics-yyyy-mm-dd", '
-                  'for the past 2 days of metrics.'),
+                         '("<static_name{date_math_expr{date_format|time_zone}}\>"). For example, an index could be '
+                         '"<metrics-{now/d}>,<metrics-{now/d-1d}>", resolving to "metrics-yyyy-mm-dd,'
+                         'metrics-yyyy-mm-dd", for the past 2 days of metrics.'),
     )
     timeout = models.IntegerField(
         default=settings.ELASTICSEARCH_TIMEOUT,

--- a/cabot/metricsapp/models/grafana.py
+++ b/cabot/metricsapp/models/grafana.py
@@ -1,0 +1,78 @@
+import requests
+import urlparse
+from django.core.exceptions import ValidationError
+from django.db import models
+
+
+class GrafanaInstance(models.Model):
+    class Meta:
+        app_label = 'metricsapp'
+
+    name = models.CharField(
+        unique=True,
+        max_length=30,
+        help_text='Unique name for Grafana site.'
+    )
+    url = models.CharField(
+        max_length=100,
+        help_text='Url of Grafana site.'
+    )
+    api_key = models.CharField(
+        max_length=100,
+        help_text='Grafana API token for authentication (http://docs.grafana.org/http_api/auth/).'
+    )
+    sources = models.ManyToManyField(
+        'MetricsSourceBase',
+        through='GrafanaDataSource',
+        help_text='Metrics sources used by this Grafana site.'
+    )
+
+    _sessions = dict()
+
+    def __unicode__(self):
+        return self.name
+
+    def clean(self, *args, **kwargs):
+        """Make sure the input url/api key work"""
+        response = self.get_request('api/search')
+
+        try:
+            response.raise_for_status()
+        except requests.exception.HTTPError:
+            raise ValidationError('Request to Grafana API failed.')
+
+    @property
+    def session(self):
+        """A requests.session object with the correct authorization headers"""
+        session = self._sessions.get(self.api_key)
+
+        if session is None:
+            session = requests.Session()
+            session.headers.update({'Authorization': 'Bearer {}'.format(self.api_key)})
+            self._sessions[self.api_key] = session
+
+        return session
+
+    def get_request(self, uri):
+        """Make a request to the Grafana instance"""
+        return self.session.get(urlparse.urljoin(self.url, uri))
+
+
+class GrafanaDataSource(models.Model):
+    """
+    Intermediate model to match the name of a data source in a Grafana instance
+    with the corresponding MetricsDataSource
+    """
+    class Meta:
+        app_label = 'metricsapp'
+
+    grafana_source_name = models.CharField(
+        max_length=30,
+        help_text='The name for a data source in grafana (e.g. metrics-stage")'
+    )
+    grafana_instance = models.ForeignKey('GrafanaInstance')
+    metrics_source_base = models.ForeignKey('MetricsSourceBase')
+
+    def __unicode__(self):
+        return '{} ({}, {})'.format(self.grafana_source_name, self.metrics_source_base.name,
+                                    self.grafana_instance.name)

--- a/cabot/metricsapp/views.py
+++ b/cabot/metricsapp/views.py
@@ -1,3 +1,0 @@
-from django.shortcuts import render
-
-# Create your views here.

--- a/cabot/metricsapp/views/__init__.py
+++ b/cabot/metricsapp/views/__init__.py
@@ -1,0 +1,3 @@
+from .grafana import GrafanaInstanceSelectView, GrafanaDashboardSelectView, GrafanaPanelSelectView, \
+    GrafanaSeriesSelectView
+from .grafana_elastic import GrafanaElasticsearchStatusCheckCreateView

--- a/cabot/metricsapp/views/grafana.py
+++ b/cabot/metricsapp/views/grafana.py
@@ -1,0 +1,142 @@
+from django.core.urlresolvers import reverse
+from django.http import HttpResponseRedirect
+from django.shortcuts import render
+from django.views.generic import View
+from cabot.cabotapp.views import LoginRequiredMixin
+from cabot.metricsapp.api import get_dashboard_info, get_dashboards, get_dashboard_choices, get_panel_choices, \
+    get_series_choices, create_generic_templating_dict
+from cabot.metricsapp.forms import GrafanaInstanceForm, GrafanaDashboardForm, GrafanaPanelForm, \
+    GrafanaSeriesForm
+from cabot.metricsapp.models import GrafanaDataSource, ElasticsearchSource, GrafanaInstance
+
+
+class GrafanaInstanceSelectView(LoginRequiredMixin, View):
+    form_class = GrafanaInstanceForm
+    template_name = 'metricsapp/grafana_create.html'
+
+    def get(self, request, *args, **kwargs):
+        instances = GrafanaInstance.objects.all()
+        # If there's only one Grafana instance, we can skip this step and just select it
+        if len(instances) == 1:
+            instance = instances[0]
+            request.session['instance_id'] = instance.id
+            request.session['all_dashboards'] = get_dashboards(instance)
+
+            return HttpResponseRedirect(reverse('grafana-dashboard-select'))
+
+        form = self.form_class()
+        return render(request, self.template_name, {'form': form})
+
+    def post(self, request, *args, **kwargs):
+        form = self.form_class(request.POST)
+
+        if form.is_valid() and not form.errors:
+            instance = form.cleaned_data['grafana_instance']
+            request.session['instance_id'] = instance.id
+            request.session['all_dashboards'] = get_dashboards(instance)
+
+            return HttpResponseRedirect(reverse('grafana-dashboard-select'))
+
+        return render(request, self.template_name, {'form': form})
+
+
+class GrafanaDashboardSelectView(LoginRequiredMixin, View):
+    form_class = GrafanaDashboardForm
+    template_name = 'metricsapp/grafana_create.html'
+
+    def get(self, request, *args, **kwargs):
+        form = self.form_class(dashboards=get_dashboard_choices(request.session['all_dashboards']))
+        return render(request, self.template_name, {'form': form})
+
+    def post(self, request, *args, **kwargs):
+        form = self.form_class(request.POST, dashboards=get_dashboard_choices(request.session['all_dashboards']))
+
+        if form.is_valid() and not form.errors:
+            dashboard_uri = form.cleaned_data['dashboard']
+            instance_id = request.session['instance_id']
+            instance = GrafanaInstance.objects.get(id=instance_id)
+
+            dashboard_info = get_dashboard_info(instance, dashboard_uri)
+            request.session['dashboard_info'] = dashboard_info
+            request.session['templating_dict'] = create_generic_templating_dict(dashboard_info)
+
+            return HttpResponseRedirect(reverse('grafana-panel-select'))
+
+        return render(request, self.template_name, {'form': form})
+
+
+class GrafanaPanelSelectView(LoginRequiredMixin, View):
+    form_class = GrafanaPanelForm
+    template_name = 'metricsapp/grafana_create.html'
+
+    def get(self, request, *args, **kwargs):
+        form = self.form_class(panels=get_panel_choices(request.session['dashboard_info'],
+                                                        request.session['templating_dict']))
+        return render(request, self.template_name, {'form': form})
+
+    def post(self, request, *args, **kwargs):
+        form = self.form_class(request.POST, panels=get_panel_choices(request.session['dashboard_info'],
+                                                                      request.session['templating_dict']))
+        if form.is_valid() and not form.errors:
+            panel_dict = form.cleaned_data['panel']
+            request.session['panel_id'] = panel_dict['panel_id']
+            request.session['datasource'] = panel_dict['datasource']
+            request.session['panel_info'] = panel_dict['panel_info']
+
+            return HttpResponseRedirect(reverse('grafana-series-select'))
+
+        return render(request, self.template_name, {'form': form})
+
+
+class GrafanaSeriesSelectView(LoginRequiredMixin, View):
+    form_class = GrafanaSeriesForm
+    template_name = 'metricsapp/grafana_create.html'
+
+    def get(self, request, *args, **kwargs):
+        series = get_series_choices(request.session['panel_info'], request.session['templating_dict'])
+        # If there's only one series, skip the page and just select it
+        if len(series) == 1:
+            request.session['series'] = [series[0][0]]
+
+            instance_id = request.session['instance_id']
+            datasource = request.session['datasource']
+            url = self.get_url_for_check_type(instance_id, datasource)
+
+            return HttpResponseRedirect(reverse(url))
+
+        form = self.form_class(series=series)
+        return render(request, self.template_name, {'form': form, 'check_type': 'Elasticsearch'})
+
+    def post(self, request, *args, **kwargs):
+        form = self.form_class(request.POST, series=get_series_choices(request.session['panel_info'],
+                                                                       request.session['templating_dict']))
+        if form.is_valid() and not form.errors:
+            request.session['series'] = form.cleaned_data['series']
+
+            instance_id = request.session['instance_id']
+            datasource = request.session['datasource']
+            url = self.get_url_for_check_type(instance_id, datasource)
+
+            return HttpResponseRedirect(reverse(url))
+
+        return render(request, self.template_name, {'form': form})
+
+    def get_url_for_check_type(self, instance_id, datasource):
+        """
+        Based on the instance id and the datasource, find the metrics source type and the
+        url for creating a check.
+        :param instance_id: id of the Grafana instance
+        :param datasource: name of the datasource in Grafana
+        :return: url for the chosen status type check
+        """
+        instance = GrafanaInstance.objects.get(id=instance_id)
+        grafana_datasource = GrafanaDataSource.objects.get(grafana_source_name=datasource,
+                                                           grafana_instance=instance)
+
+        # Pick which page to go to based on the panel chosen
+        if ElasticsearchSource.objects.filter(id=grafana_datasource.metrics_source_base.id).exists():
+            url = 'grafana-es-create'
+        else:
+            raise NotImplementedError('Check type for data source {} not implemented'.format(datasource))
+
+        return url

--- a/cabot/metricsapp/views/grafana_elastic.py
+++ b/cabot/metricsapp/views/grafana_elastic.py
@@ -1,0 +1,45 @@
+from django.core.urlresolvers import reverse
+from django.http import HttpResponseRedirect
+from django.shortcuts import render
+from django.views.generic import View
+from cabot.cabotapp.views import LoginRequiredMixin
+from cabot.metricsapp.api import get_es_status_check_fields, get_status_check_fields
+from cabot.metricsapp.forms import GrafanaElasticsearchStatusCheckForm
+
+
+class GrafanaElasticsearchStatusCheckCreateView(LoginRequiredMixin, View):
+    form_class = GrafanaElasticsearchStatusCheckForm
+    template_name = 'metricsapp/grafana_create.html'
+
+    def get(self, request, *args,  **kwargs):
+        dashboard_info = request.session['dashboard_info']
+        panel_info = request.session['panel_info']
+        instance_id = request.session['instance_id']
+        series = request.session['series']
+        datasource = request.session['datasource']
+        templating_dict = request.session['templating_dict']
+
+        form = self.form_class(fields=get_status_check_fields(dashboard_info, panel_info, instance_id,
+                                                              datasource, templating_dict),
+                               es_fields=get_es_status_check_fields(dashboard_info, panel_info, series))
+
+        return render(request, self.template_name, {'form': form, 'check_type': 'Elasticsearch'})
+
+    def post(self, request, *args, **kwargs):
+        dashboard_info = request.session['dashboard_info']
+        panel_info = request.session['panel_info']
+        instance_id = request.session['instance_id']
+        series = request.session['series']
+        datasource = request.session['datasource']
+        templating_dict = request.session['templating_dict']
+
+        form = self.form_class(request.POST,
+                               fields=get_status_check_fields(dashboard_info, panel_info, instance_id,
+                                                              datasource, templating_dict),
+                               es_fields=get_es_status_check_fields(dashboard_info, panel_info, series))
+
+        if form.is_valid() and not form.errors:
+            check = form.save()
+            return HttpResponseRedirect(reverse('check', kwargs={'pk': check.id}))
+
+        return render(request, self.template_name, {'form': form, 'check_type': 'Elasticsearch'})

--- a/cabot/templates/base.html
+++ b/cabot/templates/base.html
@@ -69,6 +69,9 @@
                   <a class="submenu" href="#"><i class="fa fa-cog"></i> Status check <span class="caret"></span></a>
                   <ul class="dropdown-menu">
                     <li>
+                      <a href="{% url "grafana-instance-select" %}" class=""><i class="glyphicon glyphicon-stats" title="Add new Grafana check"></i> Grafana</a>
+                    </li>
+                    <li>
                       <a href="{% url "create-influxdb-check" %}?service={{ service.id }}&instance={{ instance.id }}" class=""><i class="glyphicon glyphicon-signal" title="Add new metric check"></i> InfluxDB</a>
                     </li>
                     <li>

--- a/cabot/templates/metricsapp/grafana_create.html
+++ b/cabot/templates/metricsapp/grafana_create.html
@@ -1,0 +1,27 @@
+{% extends 'base.html' %}
+
+{% block content %}
+<div class="row">
+  <div class="col-xs-12">
+    <div class="col-xs-10 col-xs-offset-2">
+      {% if check_type %}
+        <h2>New {{ check_type }} Status Check from Grafana</h2>
+      {% else %}
+        <h2>New Status Check from Grafana</h2>
+      {% endif %}
+    </div>
+  </div>
+</div>
+
+<form class="form-horizontal" action="" method="post" role="form">
+  {% include "cabotapp/_base_form.html" %}
+  <div class="colx-xs-12">
+    <div class="form-group">
+      <div class="col-xs-6 col-xs-offset-2">
+        <button type="submit" class="btn btn-primary">Submit</button>
+        <a href="{% url "dashboard" %}" class="btn">Back to dashboard</a>
+      </div>
+    </div>
+  </div>
+</form>
+{% endblock %}

--- a/cabot/urls.py
+++ b/cabot/urls.py
@@ -26,6 +26,11 @@ from cabot.cabotapp.views import (
     UserProfileUpdateView, ShiftListView, subscriptions,
 )
 
+from cabot.metricsapp.views import (
+    GrafanaInstanceSelectView, GrafanaDashboardSelectView,
+    GrafanaPanelSelectView, GrafanaElasticsearchStatusCheckCreateView,
+    GrafanaSeriesSelectView
+)
 from cabot import rest_urls
 
 from django.contrib import admin
@@ -120,6 +125,13 @@ urlpatterns = patterns('',
     url(r'^schedule/create/', view=ScheduleCreateView.as_view(), name='create-schedule'),
     url(r'^schedule/update/(?P<pk>\d+)/', view=ScheduleUpdateView.as_view(), name='update-schedule'),
     url(r'^schedule/delete/(?P<pk>\d+)/', view=ScheduleDeleteView.as_view(), name='delete-schedule'),
+
+    url(r'^grafana/instance/', view=GrafanaInstanceSelectView.as_view(), name='grafana-instance-select'),
+    url(r'^grafana/dashboard/', view=GrafanaDashboardSelectView.as_view(), name='grafana-dashboard-select'),
+    url(r'^grafana/panel/', view=GrafanaPanelSelectView.as_view(), name='grafana-panel-select'),
+    url(r'^grafana/series/', view=GrafanaSeriesSelectView.as_view(), name='grafana-series-select'),
+    url(r'^grafana/elasticsearch/create/', view=GrafanaElasticsearchStatusCheckCreateView.as_view(),
+        name='grafana-es-create'),
 
     # Comment below line to disable browsable rest api
     url(r'^api-auth/',

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,6 +34,7 @@ kombu==3.0.30
 mock==1.0.1
 psycogreen==1.0
 psycopg2==2.5.1
+pytimeparse==1.1.6
 pytz==2014.10
 redis==2.9.0
 requests==2.7.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,3 @@
 [flake8]
 max-line-length = 120
-exclude=cabot/cabotapp/migrations/*,.venv/*,fabfile.py,cabot/metricsapp/migrations/*,cabot/dummyapp/migrations/*,cabot/metricsapp/models/__init__.py,cabot/metricsapp/api/__init__.py,cabot/metricsapp/forms/__init__.py
+exclude=cabot/cabotapp/migrations/*,.venv/*,fabfile.py,cabot/metricsapp/migrations/*,cabot/dummyapp/migrations/*,cabot/metricsapp/models/__init__.py,cabot/metricsapp/api/__init__.py,cabot/metricsapp/forms/__init__.py,cabot/metricsapp/views/__init__.py


### PR DESCRIPTION
On top of https://github.com/Affirm/cabot/pull/40, actual changes are in https://github.com/Affirm/cabot/pull/45/commits/3abb1ceae9d6291dc86a668170742f52623eb7bd.

- Models for Grafana Instance (grafana site) and GrafanaDataSource (links the name of a data source in Grafana to the GrafanaInstance and MetricsSourceBase objects)
- Views/forms/template for selecting a GrafanaInstance, dashboard, panel, and series
- Autofill ElasticcsearchStatusCheck form based on panel/series info
- ElasticsearchStatusCheck creation form

Tested creating checks based on some dashboards (web, prequal, charlotte, etc.), in general worked but more testing necessary. Ran into several issues with Grafana autofill values in the API response that I had to make special cases for--I'm sure there are more issues I haven't found yet. 

TODO: test cases for Grafana API parsing, handle more edge cases (and fail more gracefully) (these will be in https://github.com/Affirm/cabot/pull/46)

In future PRs: update/delete check views, refesh check based on dashboard changes, celery task for checking if a dashboard changes and emailing owners, etc. 