### PR TITLE
Infra 3710 tests

### DIFF
--- a/cabot/metricsapp/tests/fixtures/elastic/grafana/query_builder/get_es_status_check_fields_queries.json
+++ b/cabot/metricsapp/tests/fixtures/elastic/grafana/query_builder/get_es_status_check_fields_queries.json
@@ -1,0 +1,98 @@
+[
+  [
+    {
+      "query": {
+        "bool": {
+          "must": [
+            {
+              "query_string": {
+                "analyze_wildcard": true,
+                "query": "query:life-the-universe-and-everything"
+              }
+            },
+            {
+              "range": {
+                "@timestamp": {
+                  "gte": "now-3h"
+                }
+              }
+            }
+          ]
+        }
+      },
+      "aggs": {
+        "agg": {
+          "date_histogram": {
+            "field": "@timestamp",
+            "interval": "1m",
+            "extended_bounds": {
+              "max": "now",
+              "min": "now-3h"
+            }
+          },
+          "aggs": {
+            "sum": {
+              "sum": {
+                "field": "value"
+              }
+            }
+          }
+        }
+      }
+    }
+  ],
+  [
+    {
+      "query": {
+        "bool": {
+          "must": [
+            {
+              "query_string": {
+                "analyze_wildcard": true,
+                "query": "name:the-goat AND module:(module)"
+              }
+            },
+            {
+              "range": {
+                "@timestamp": {
+                  "gte": "now-3h"
+                }
+              }
+            }
+          ]
+        }
+      },
+      "aggs": {
+        "agg": {
+          "terms": {
+            "field": "wrigley",
+            "min_doc_count": 1,
+            "size": 20
+          },
+          "aggs": {
+            "agg": {
+              "date_histogram": {
+                "field": "@timestamp",
+                "interval": "1m",
+                "extended_bounds": {
+                  "max": "now",
+                  "min": "now-3h"
+                }
+              },
+              "aggs": {
+                "percentiles": {
+                  "percentiles": {
+                    "field": "timing",
+                    "percents": [
+                      "75"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
+]

--- a/cabot/metricsapp/tests/fixtures/grafana/dashboard_detail_response.json
+++ b/cabot/metricsapp/tests/fixtures/grafana/dashboard_detail_response.json
@@ -1,0 +1,565 @@
+{
+  "meta": {
+    "isStarred": true,
+    "type": "db",
+    "canSave": true,
+    "canEdit": true,
+    "canStar": true,
+    "slug": "web",
+    "expires": "0004-03-03T00:00:00Z",
+    "created": "2013-01-24T00:00:00Z",
+    "updated": "2017-02-01T00:00:00Z",
+    "updatedBy": "admin",
+    "createdBy": "admin",
+    "version": 513 
+  },
+  "dashboard": {
+    "annotations": {
+      "list": [
+        
+      ]
+    },
+    "editMode": false,
+    "editable": true,
+    "gnetId": null,
+    "graphTooltip": 1,
+    "hideControls": false,
+    "id": 95,
+    "links": [
+      
+    ],
+    "refresh": false,
+    "rows": [
+      {
+        "collapse": false,
+        "height": "250px",
+        "panels": [
+          {
+            "aliasColors": {
+              
+            },
+            "bars": false,
+            "datasource": "deep-thought",
+            "fill": 1,
+            "id": 1,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [
+              
+            ],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+              {
+                "alias": "42",
+                "yaxis": 2
+              }
+            ],
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "alias": "42",
+                "bucketAggs": [
+                  {
+                    "field": "@timestamp",
+                    "id": "2",
+                    "settings": {
+                      "interval": "$group_by",
+                      "min_doc_count": 0,
+                      "trimEdges": 0
+                    },
+                    "type": "date_histogram"
+                  }
+                ],
+                "dsType": "elasticsearch",
+                "metrics": [
+                  {
+                    "field": "value",
+                    "id": "1",
+                    "meta": {
+
+                    },
+                    "settings": {
+
+                    },
+                    "type": "sum"
+                  }
+                ],
+                "query": "query:life-the-universe-and-everything",
+                "refId": "B",
+                "timeField": "@timestamp"
+              }
+            ],
+            "thresholds": [
+              {
+                "colorMode": "critical",
+                "fill": true,
+                "line": true,
+                "op": "gt",
+                "value": 1
+              },
+              {
+                "colorMode": "warning",
+                "op": "gt",
+                "value": 0
+              }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "42",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": [
+                
+              ]
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": "42",
+                "logBase": 1,
+                "max": null,
+                "min": "0",
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {
+
+            },
+            "bars": false,
+            "datasource": "shallow-thought",
+            "fill": 1,
+            "id": 5,
+            "legend": {
+              "alignAsTable": true,
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "rightSide": true,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [
+
+            ],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+              {
+                "alias": "al",
+                "yaxis": 2
+              }
+            ],
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "alias": "al",
+                "bucketAggs": [
+                  {
+                    "fake": true,
+                    "field": "@timestamp",
+                    "id": "3",
+                    "settings": {
+                      "interval": "$group_by",
+                      "min_doc_count": 0,
+                      "trimEdges": 0
+                    },
+                    "type": "date_histogram"
+                  }
+                ],
+                "dsType": "elasticsearch",
+                "metrics": [
+                  {
+                    "field": "count",
+                    "id": "1",
+                    "meta": {
+
+                    },
+                    "settings": {
+
+                    },
+                    "type": "sum"
+                  }
+                ],
+                "query": "query:who-cares",
+                "refId": "A",
+                "timeField": "@timestamp"
+              }
+            ],
+            "thresholds": [
+              {
+                "colorMode": "warning",
+                "op": "lt",
+                "value": 100
+              }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Pct $percentile_1",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": [
+
+              ]
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": "",
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": "",
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": false
+              }
+            ]
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": false,
+        "title": "Dashboard Row",
+        "titleSize": "h6"
+      },
+      {
+        "collapse": false,
+        "height": 250,
+        "panels": [
+          {
+            "aliasColors": {
+            },
+            "bars": false,
+            "datasource": "ds",
+            "fill": 0,
+            "id": 3,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [
+            ],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+              {
+                "alias": "2",
+                "yaxis": 2
+              },
+              {
+                "alias": "1",
+                "yaxis": 1
+              }
+            ],
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "bucketAggs": [
+                  {
+                    "fake": true,
+                    "field": "wrigley",
+                    "id": "3",
+                    "settings": {
+                      "min_doc_count": 1,
+                      "size": "20"
+                    },
+                    "type": "terms"
+                  },
+                  {
+                    "field": "@timestamp",
+                    "id": "2",
+                    "settings": {
+                      "interval": "$group_by",
+                      "min_doc_count": 0,
+                      "trimEdges": 0
+                    },
+                    "type": "date_histogram"
+                  }
+                ],
+                "dsType": "elasticsearch",
+                "metrics": [
+                  {
+                    "field": "timing",
+                    "id": "1",
+                    "meta": {
+                    },
+                    "settings": {
+                      "percents": [
+                        "$percentile_1"
+                      ]
+                    },
+                    "type": "percentiles"
+                  }
+                ],
+                "query": "name:the-goat AND module:$module",
+                "refId": "B",
+                "timeField": "@timestamp"
+              }
+            ],
+            "thresholds": [
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Panel 106",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": [
+              ]
+            },
+            "yaxes": [
+              {
+                "format": "ms",
+                "label": "",
+                "logBase": 10,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "ms",
+                "label": "",
+                "logBase": 10,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": false,
+        "title": "Dashboard Row",
+        "titleSize": "h6"
+      }
+    ],
+    "schemaVersion": 14,
+    "style": "dark",
+    "tags": [
+      
+    ],
+    "templating": {
+      "list": [
+        {
+          "allValue": null,
+          "current": {
+            "text": "All",
+            "value": [
+              "module"
+            ]
+          },
+          "datasource": "who-cares",
+          "hide": 0,
+          "includeAll": true,
+          "label": "Module",
+          "multi": true,
+          "name": "module",
+          "options": [
+            
+          ],
+          "query": "query",
+          "refresh": 1,
+          "regex": "",
+          "sort": 0,
+          "tagValuesQuery": "",
+          "tags": [
+            
+          ],
+          "tagsQuery": "",
+          "type": "query",
+          "useTags": false
+        },
+        {
+          "auto": true,
+          "auto_count": 30,
+          "auto_min": "10s",
+          "current": {
+            "text": "1m",
+            "value": "1m"
+          },
+          "hide": 0,
+          "label": "Group By",
+          "name": "group_by",
+          "options": [
+            {
+              "selected": false,
+              "text": "auto",
+              "value": "$__auto_interval"
+            },
+            {
+              "selected": true,
+              "text": "1m",
+              "value": "1m"
+            },
+            {
+              "selected": false,
+              "text": "10m",
+              "value": "10m"
+            },
+            {
+              "selected": false,
+              "text": "30m",
+              "value": "30m"
+            }
+          ],
+          "query": "1m,10m,30m",
+          "refresh": 2,
+          "type": "interval"
+        },
+        {
+          "allValue": null,
+          "current": {
+            "selected": true,
+            "text": "75",
+            "value": "75"
+          },
+          "hide": 0,
+          "includeAll": false,
+          "label": "Percentile (Left)",
+          "multi": false,
+          "name": "percentile_1",
+          "options": [
+            {
+              "selected": false,
+              "text": "50",
+              "value": "50"
+            },
+            {
+              "selected": true,
+              "text": "75",
+              "value": "75"
+            },
+            {
+              "selected": false,
+              "text": "90",
+              "value": "90"
+            },
+            {
+              "selected": false,
+              "text": "95",
+              "value": "95"
+            },
+            {
+              "selected": false,
+              "text": "99",
+              "value": "99"
+            }
+          ],
+          "query": "50,75,90,95,99",
+          "type": "custom"
+        },
+        {
+          "datasource": "ds",
+          "filters": [
+            
+          ],
+          "hide": 0,
+          "label": "Ad-hoc Filters",
+          "name": "filters",
+          "type": "adhoc"
+        }
+      ]
+    },
+    "time": {
+      "from": "now-3h",
+      "to": "now"
+    },
+    "timepicker": {
+      "refresh_intervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "time_options": [
+        "5m",
+        "15m",
+        "1h",
+        "6h",
+        "12h",
+        "24h",
+        "2d",
+        "7d",
+        "30d"
+      ]
+    },
+    "timezone": "browser",
+    "title": "Also Great Dashboard",
+    "version": 95
+  }
+}

--- a/cabot/metricsapp/tests/fixtures/grafana/dashboard_list_response.json
+++ b/cabot/metricsapp/tests/fixtures/grafana/dashboard_list_response.json
@@ -1,0 +1,43 @@
+[
+  {
+    "id": 1,
+    "title": "Awesome Dashboard",
+    "uri": "db\/awesome-dashboard",
+    "type": "dash-db",
+    "tags": [
+      "thebest",
+      "infrastructure"
+    ],
+    "isStarred": false
+  },
+  {
+    "id": 2,
+    "title": "Really Really Good Dashboard",
+    "uri": "db\/really-really-good-dashboard",
+    "type": "dash-db",
+    "tags": [
+      "monitoring"
+    ],
+    "isStarred": false
+  },
+  {
+    "id": 3,
+    "title": "Also Great Dashboard",
+    "uri": "db\/also-great-dashboard",
+    "type": "dash-db",
+    "tags": [
+      
+    ],
+    "isStarred": false
+  },
+  {
+    "id": 123454321,
+    "title": "Only Ok Dashboard",
+    "uri": "db\/only-ok-dashboard",
+    "type": "dash-db",
+    "tags": [
+      
+    ],
+    "isStarred": false
+  }
+]

--- a/cabot/metricsapp/tests/test_grafana.py
+++ b/cabot/metricsapp/tests/test_grafana.py
@@ -1,0 +1,136 @@
+import json
+import os
+from django.test import TestCase
+from mock import patch
+from cabot.metricsapp.api import get_dashboard_choices, get_panel_choices, create_generic_templating_dict, \
+    get_series_choices, get_status_check_fields
+from cabot.metricsapp.models import GrafanaInstance
+
+
+def get_json_file(file):
+    path = os.path.join(os.path.dirname(__file__), 'fixtures/grafana/{}'.format(file))
+    with open(path) as f:
+        return json.loads(f.read())
+
+
+class TestGrafanaApiParsing(TestCase):
+    def setUp(self):
+        self.dashboard_list = get_json_file('dashboard_list_response.json')
+        self.dashboard_info = get_json_file('dashboard_detail_response.json')
+        self.templating_dict = create_generic_templating_dict(self.dashboard_info)
+
+    def test_get_dashboard_choices(self):
+        choices = get_dashboard_choices(self.dashboard_list)
+
+        expected_choices = [('db/awesome-dashboard', 'Awesome Dashboard'),
+                            ('db/really-really-good-dashboard', 'Really Really Good Dashboard'),
+                            ('db/also-great-dashboard', 'Also Great Dashboard'),
+                            ('db/only-ok-dashboard', 'Only Ok Dashboard')]
+
+        self.assertEqual(choices, expected_choices)
+
+    def test_get_panel_choices(self):
+        choices = get_panel_choices(self.dashboard_info, self.templating_dict)
+        # Remove extended panel data from choices
+        choices = [(dict(panel_id=panel[0]['panel_id'], datasource=panel[0]['datasource']),
+                    panel[1]) for panel in choices]
+
+        # ({id, datasource}, title)
+        expected_choices = [(dict(panel_id=1, datasource='deep-thought'), '42'),
+                            (dict(panel_id=5, datasource='shallow-thought'), 'Pct 75'),
+                            (dict(panel_id=3, datasource='ds'), 'Panel 106')]
+
+        self.assertEqual(choices, expected_choices)
+
+    def test_get_series_choices(self):
+        series_choices = []
+        for row in self.dashboard_info['dashboard']['rows']:
+            for panel in row['panels']:
+                series = get_series_choices(panel, self.templating_dict)
+                series_choices.append([(s[0], json.loads(s[1])) for s in series])
+
+        expected_series_choices = [
+            [(u'B', dict(alias='42',
+                         bucketAggs=[dict(field='@timestamp',
+                                          id='2',
+                                          settings=dict(interval='1m', min_doc_count=0, trimEdges=0),
+                                          type='date_histogram')],
+                         metrics=[dict(field='value',
+                                       id='1',
+                                       meta={},
+                                       settings={},
+                                       type='sum')],
+                         query='query:life-the-universe-and-everything'))],
+            [(u'A', dict(alias='al',
+                         bucketAggs=[dict(fake=True,
+                                          field='@timestamp',
+                                          id='3',
+                                          settings=dict(interval='1m', min_doc_count=0, trimEdges=0),
+                                          type='date_histogram')],
+                         metrics=[dict(field='count',
+                                       id='1',
+                                       meta={},
+                                       settings={},
+                                       type='sum')],
+                         query='query:who-cares'))],
+            [(u'B', dict(bucketAggs=[dict(fake=True,
+                                          field='wrigley',
+                                          id='3',
+                                          settings=dict(min_doc_count=1, size='20'),
+                                          type='terms'),
+                                     dict(field='@timestamp',
+                                          id='2',
+                                          settings=dict(interval='1m', min_doc_count=0, trimEdges=0),
+                                          type='date_histogram')],
+                         metrics=[dict(field='timing',
+                                       id='1',
+                                       meta={},
+                                       settings=dict(percents=['75']),
+                                       type='percentiles')],
+                         query='name:the-goat AND module:module'))]
+        ]
+
+        self.assertEqual(series_choices, expected_series_choices)
+
+    def test_get_status_check_fields(self):
+        status_check_fields = []
+        for row in self.dashboard_info['dashboard']['rows']:
+            for panel in row['panels']:
+                status_check_fields.append(get_status_check_fields(self.dashboard_info, panel, 1, 'datasource',
+                                                                   self.templating_dict))
+
+        expected_fields = [
+            dict(name='42',
+                 source_info=dict(grafana_source_name='datasource', grafana_instance_id=1),
+                 time_range=180,
+                 high_alert_value=1.0,
+                 check_type='>',
+                 warning_value=0.0),
+            dict(name='Pct 75',
+                 source_info=dict(grafana_source_name='datasource', grafana_instance_id=1),
+                 time_range=180,
+                 warning_value=100.0,
+                 check_type='<'),
+            dict(name='Panel 106',
+                 source_info=dict(grafana_source_name='datasource', grafana_instance_id=1),
+                 time_range=180)
+        ]
+
+        self.assertEqual(status_check_fields, expected_fields)
+
+
+class TestGrafanaApiRequests(TestCase):
+    def setUp(self):
+        self.grafana_instance = GrafanaInstance.objects.create(
+            name='test',
+            url='http://test.url',
+            api_key='88888'
+        )
+
+    def test_auth_header(self):
+        self.assertTrue(self.grafana_instance.session.headers['Authorization'] == 'Bearer 88888')
+
+    @patch('cabot.metricsapp.models.grafana.requests.Session.get')
+    def test_get_request(self, fake_get):
+        self.grafana_instance.get_request('index.html')
+        fake_get.assert_called_once_with('http://test.url/index.html')


### PR DESCRIPTION
tests for #45, ready for review please!

The tests cover all the new functions in api/grafana.py and api/grafana_elastic.py (besides the ones that are just getting and returning data from the Grafana API, which would have to be mocked completely. I tried to cover a variety of situations with templating, automatically set fields, and multiple aggs/metrics.