### PR TITLE
Infra 3712 celery task for grafana updates

### DIFF
--- a/cabot/celeryconfig.py
+++ b/cabot/celeryconfig.py
@@ -1,6 +1,7 @@
 import os
 from datetime import timedelta
 from kombu import Exchange, Queue
+from cabot.metricsapp.defs import GRAFANA_SYNC_TIMEDELTA_MINUTES
 
 BROKER_URL = os.environ['CELERY_BROKER_URL']
 CELERY_IMPORTS = (
@@ -25,6 +26,10 @@ CELERYBEAT_SCHEDULE = {
     'clean-db': {
         'task': 'cabot.cabotapp.tasks.clean_db',
         'schedule': timedelta(seconds=60*60*24),
+    },
+    'sync-all-grafana-checks': {
+        'task': 'cabot.metricsapp.tasks.sync_all_grafana_checks',
+        'schedule': timedelta(seconds=GRAFANA_SYNC_TIMEDELTA_MINUTES * 60)
     },
 }
 
@@ -65,6 +70,18 @@ CELERY_ROUTES = {
         'queue': 'maintenance',
         'routing_key': 'maintenance',
     },
+    'cabot.metricsapp.tasks.sync_all_grafana_checks': {
+        'queue': 'batch',
+        'routing_key': 'batch',
+    },
+    'cabot.metricsapp.tasks.sync_grafana_check': {
+        'queue': 'batch',
+        'routing_key': 'batch',
+    },
+    'cabot.metricsapp.tasks.send_grafana_sync_email': {
+        'queue': 'batch',
+        'routing_key': 'batch'
+    }
 }
 
 CELERY_TIMEZONE = 'UTC'

--- a/cabot/metricsapp/api/__init__.py
+++ b/cabot/metricsapp/api/__init__.py
@@ -4,4 +4,4 @@ from .grafana_elastic import build_query, template_response, create_elasticsearc
     get_es_status_check_fields
 from .grafana import get_dashboards, get_dashboard_choices, get_dashboard_info, \
     get_panel_choices, get_series_choices, template_response, create_generic_templating_dict, \
-    get_status_check_fields, get_panel_url
+    get_status_check_fields, get_panel_url, get_updated_datetime, get_panel_info, get_series_ids

--- a/cabot/metricsapp/defs.py
+++ b/cabot/metricsapp/defs.py
@@ -7,3 +7,5 @@ ES_VALIDATION_MSG_PREFIX = 'Elasticsearch query format error'
 ES_TIME_RANGE = 'now-10m'
 
 ES_DEFAULT_INTERVAL = '1m'
+
+GRAFANA_SYNC_TIMEDELTA_MINUTES = 30

--- a/cabot/metricsapp/forms/grafana.py
+++ b/cabot/metricsapp/forms/grafana.py
@@ -1,6 +1,6 @@
 from django import forms
 from cabot.cabotapp.views import StatusCheckForm
-from cabot.metricsapp.models import GrafanaInstance, GrafanaDataSource
+from cabot.metricsapp.models import GrafanaInstance, GrafanaDataSource, GrafanaPanel
 
 
 # Model forms for admin site
@@ -100,10 +100,12 @@ class GrafanaStatusCheckForm(StatusCheckForm):
                 self.fields[field_name].initial = field_value
                 self.fields[field_name].help_text += ' Autofilled from the Grafana dashboard.'
 
-        # Store fields for the source, which will be set in save()
+        # Store fields that will be set in save()
         source_info = fields['source_info']
         self.grafana_source_name = source_info['grafana_source_name']
         self.grafana_instance_id = source_info['grafana_instance_id']
+
+        self.grafana_panel = GrafanaPanel.objects.get(id=fields['grafana_panel'])
 
     def save(self):
         # set the MetricsSourceBase here so we don't have to display it
@@ -113,6 +115,7 @@ class GrafanaStatusCheckForm(StatusCheckForm):
             grafana_source_name=self.grafana_source_name,
             grafana_instance_id=self.grafana_instance_id,
         ).metrics_source_base
+        model.grafana_panel = self.grafana_panel
 
         model.save()
         return model

--- a/cabot/metricsapp/forms/grafana_elastic.py
+++ b/cabot/metricsapp/forms/grafana_elastic.py
@@ -11,6 +11,7 @@ class GrafanaElasticsearchStatusCheckForm(GrafanaStatusCheckForm):
             'name',
             'queries',
             'active',
+            'auto_sync',
             'check_type',
             'warning_value',
             'high_alert_importance',
@@ -19,6 +20,9 @@ class GrafanaElasticsearchStatusCheckForm(GrafanaStatusCheckForm):
             'retries',
             'time_range',
         ]
+        widgets = {
+            'auto_sync': forms.CheckboxInput()
+        }
 
     def __init__(self, *args, **kwargs):
         es_fields = kwargs.pop('es_fields')

--- a/cabot/metricsapp/migrations/0005_auto__add_grafanapanel__add_field_metricsstatuscheckbase_grafana_panel.py
+++ b/cabot/metricsapp/migrations/0005_auto__add_grafanapanel__add_field_metricsstatuscheckbase_grafana_panel.py
@@ -1,0 +1,151 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding model 'GrafanaPanel'
+        db.create_table(u'metricsapp_grafanapanel', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('grafana_instance', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['metricsapp.GrafanaInstance'])),
+            ('dashboard_uri', self.gf('django.db.models.fields.CharField')(max_length=40)),
+            ('panel_id', self.gf('django.db.models.fields.IntegerField')()),
+            ('series_ids', self.gf('django.db.models.fields.CharField')(max_length=20)),
+            ('selected_series', self.gf('django.db.models.fields.CharField')(max_length=20)),
+        ))
+        db.send_create_signal('metricsapp', ['GrafanaPanel'])
+
+        # Adding field 'MetricsStatusCheckBase.grafana_panel'
+        db.add_column(u'metricsapp_metricsstatuscheckbase', 'grafana_panel',
+                      self.gf('django.db.models.fields.related.ForeignKey')(to=orm['metricsapp.GrafanaPanel'], null=True),
+                      keep_default=False)
+
+        # Adding field 'MetricsStatusCheckBase.auto_sync'
+        db.add_column(u'metricsapp_metricsstatuscheckbase', 'auto_sync',
+                      self.gf('django.db.models.fields.NullBooleanField')(default=False, null=True, blank=True),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting model 'GrafanaPanel'
+        db.delete_table(u'metricsapp_grafanapanel')
+
+        # Deleting field 'MetricsStatusCheckBase.grafana_panel'
+        db.delete_column(u'metricsapp_metricsstatuscheckbase', 'grafana_panel_id')
+
+        # Deleting field 'MetricsStatusCheckBase.auto_sync'
+        db.delete_column(u'metricsapp_metricsstatuscheckbase', 'auto_sync')
+
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'cabotapp.statuscheck': {
+            'Meta': {'ordering': "['name']", 'object_name': 'StatusCheck'},
+            'active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'cached_health': ('django.db.models.fields.TextField', [], {'null': 'True'}),
+            'calculated_status': ('django.db.models.fields.CharField', [], {'default': "'passing'", 'max_length': '50', 'blank': 'True'}),
+            'created_by': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']", 'null': 'True'}),
+            'frequency': ('django.db.models.fields.IntegerField', [], {'default': '5'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'importance': ('django.db.models.fields.CharField', [], {'default': "'ERROR'", 'max_length': '30'}),
+            'last_run': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            'name': ('django.db.models.fields.TextField', [], {}),
+            'polymorphic_ctype': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'polymorphic_cabotapp.statuscheck_set'", 'null': 'True', 'to': u"orm['contenttypes.ContentType']"}),
+            'retries': ('django.db.models.fields.IntegerField', [], {'default': '0', 'null': 'True'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'metricsapp.elasticsearchsource': {
+            'Meta': {'object_name': 'ElasticsearchSource', '_ormbases': ['metricsapp.MetricsSourceBase']},
+            'index': ('django.db.models.fields.TextField', [], {'default': "'*'", 'max_length': '50'}),
+            'max_concurrent_searches': ('django.db.models.fields.IntegerField', [], {'default': 'None', 'null': 'True'}),
+            u'metricssourcebase_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['metricsapp.MetricsSourceBase']", 'unique': 'True', 'primary_key': 'True'}),
+            'timeout': ('django.db.models.fields.IntegerField', [], {'default': '20'}),
+            'urls': ('django.db.models.fields.TextField', [], {'max_length': '250'})
+        },
+        'metricsapp.elasticsearchstatuscheck': {
+            'Meta': {'ordering': "['name']", 'object_name': 'ElasticsearchStatusCheck', '_ormbases': ['metricsapp.MetricsStatusCheckBase']},
+            u'metricsstatuscheckbase_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['metricsapp.MetricsStatusCheckBase']", 'unique': 'True', 'primary_key': 'True'}),
+            'queries': ('django.db.models.fields.TextField', [], {'max_length': '10000'})
+        },
+        'metricsapp.grafanadatasource': {
+            'Meta': {'object_name': 'GrafanaDataSource'},
+            'grafana_instance': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['metricsapp.GrafanaInstance']"}),
+            'grafana_source_name': ('django.db.models.fields.CharField', [], {'max_length': '30'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'metrics_source_base': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['metricsapp.MetricsSourceBase']"})
+        },
+        'metricsapp.grafanainstance': {
+            'Meta': {'object_name': 'GrafanaInstance'},
+            'api_key': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'}),
+            'sources': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['metricsapp.MetricsSourceBase']", 'through': "orm['metricsapp.GrafanaDataSource']", 'symmetrical': 'False'}),
+            'url': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'metricsapp.grafanapanel': {
+            'Meta': {'object_name': 'GrafanaPanel'},
+            'dashboard_uri': ('django.db.models.fields.CharField', [], {'max_length': '40'}),
+            'grafana_instance': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['metricsapp.GrafanaInstance']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'panel_id': ('django.db.models.fields.IntegerField', [], {}),
+            'selected_series': ('django.db.models.fields.CharField', [], {'max_length': '20'}),
+            'series_ids': ('django.db.models.fields.CharField', [], {'max_length': '20'})
+        },
+        'metricsapp.metricssourcebase': {
+            'Meta': {'object_name': 'MetricsSourceBase'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'metricsapp.metricsstatuscheckbase': {
+            'Meta': {'ordering': "['name']", 'object_name': 'MetricsStatusCheckBase', '_ormbases': [u'cabotapp.StatusCheck']},
+            'auto_sync': ('django.db.models.fields.NullBooleanField', [], {'default': 'False', 'null': 'True', 'blank': 'True'}),
+            'check_type': ('django.db.models.fields.CharField', [], {'max_length': '30'}),
+            'grafana_panel': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['metricsapp.GrafanaPanel']", 'null': 'True'}),
+            'high_alert_importance': ('django.db.models.fields.CharField', [], {'default': "'ERROR'", 'max_length': '30'}),
+            'high_alert_value': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'source': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['metricsapp.MetricsSourceBase']"}),
+            u'statuscheck_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['cabotapp.StatusCheck']", 'unique': 'True', 'primary_key': 'True'}),
+            'time_range': ('django.db.models.fields.IntegerField', [], {'default': '30'}),
+            'warning_value': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['metricsapp']

--- a/cabot/metricsapp/models/__init__.py
+++ b/cabot/metricsapp/models/__init__.py
@@ -1,3 +1,3 @@
 from .base import MetricsSourceBase, MetricsStatusCheckBase
 from .elastic import ElasticsearchSource, ElasticsearchStatusCheck
-from .grafana import GrafanaInstance, GrafanaDataSource
+from .grafana import GrafanaInstance, GrafanaDataSource, GrafanaPanel

--- a/cabot/metricsapp/models/base.py
+++ b/cabot/metricsapp/models/base.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.db import models
 from cabot.cabotapp.models import CHECK_TYPES, Service, StatusCheck
 from cabot.metricsapp.api import run_metrics_check
@@ -26,7 +27,7 @@ class MetricsStatusCheckBase(StatusCheck):
         (Service.CRITICAL_STATUS, 'Critical'),
     )
 
-    source = models.ForeignKey(MetricsSourceBase)
+    source = models.ForeignKey('MetricsSourceBase')
     check_type = models.CharField(
         choices=CHECK_TYPES,
         max_length=30
@@ -52,6 +53,16 @@ class MetricsStatusCheckBase(StatusCheck):
     time_range = models.IntegerField(
         default=30,
         help_text='Time range in minutes the check gathers data for.',
+    )
+    grafana_panel = models.ForeignKey(
+        'GrafanaPanel',
+        null=True
+    )
+    auto_sync = models.NullBooleanField(
+        default=True,
+        null=True,
+        help_text='For Grafana status checks--should Cabot poll Grafana for dashboard updates and automatically '
+                  'update the check?'
     )
 
     def _run(self):
@@ -79,3 +90,7 @@ class MetricsStatusCheckBase(StatusCheck):
         :return the parsed data
         """
         raise NotImplementedError('MetricsStatusCheckBase has no data source.')
+
+    def get_url_for_check(self):
+        """Get the url for viewing this check"""
+        return '{}://{}/check/{}/'.format(settings.WWW_SCHEME, settings.WWW_HTTP_HOST, self.id)

--- a/cabot/metricsapp/models/grafana.py
+++ b/cabot/metricsapp/models/grafana.py
@@ -76,3 +76,17 @@ class GrafanaDataSource(models.Model):
     def __unicode__(self):
         return '{} ({}, {})'.format(self.grafana_source_name, self.metrics_source_base.name,
                                     self.grafana_instance.name)
+
+
+class GrafanaPanel(models.Model):
+    """
+    Data about a Grafana panel.
+    """
+    class Meta:
+        app_label = 'metricsapp'
+
+    grafana_instance = models.ForeignKey('GrafanaInstance')
+    dashboard_uri = models.CharField(max_length=40)
+    panel_id = models.IntegerField()
+    series_ids = models.CharField(max_length=20)
+    selected_series = models.CharField(max_length=20)

--- a/cabot/metricsapp/tasks.py
+++ b/cabot/metricsapp/tasks.py
@@ -1,0 +1,186 @@
+import logging
+import json
+import os
+from celery.task import task
+from datetime import datetime, timedelta
+from django.contrib.auth.models import User
+from django.core.exceptions import ValidationError
+from django.core.mail import send_mail
+from django.template import Context, Template
+from cabot.metricsapp.api import get_dashboard_info, get_updated_datetime, get_panel_info, \
+    create_generic_templating_dict, template_response, get_es_status_check_fields, get_series_ids
+from cabot.metricsapp.defs import GRAFANA_SYNC_TIMEDELTA_MINUTES
+from cabot.metricsapp.models import MetricsStatusCheckBase, ElasticsearchStatusCheck, GrafanaDataSource
+from cabot.metricsapp.templates import NAME_CHANGED, SOURCE_CHANGED_EXISTING, SOURCE_CHANGED_NONEXISTING, \
+    SERIES_CHANGED, ES_QUERIES_CHANGED
+
+
+logger = logging.getLogger(__name__)
+
+
+def _dashboard_deleted_handler(check, panel):
+    """
+    When the dashboard is deleted in Grafana, deactivate the check and send an email
+    :param check: the status check
+    :param panel: the GrafanaPanel object
+    :return None
+    """
+    check.active = False
+    check.save()
+    send_grafana_sync_email.apply_async(args=([str(check.created_by.email)],
+                                              '{}\n\n'
+                                              'Dashboard "{}" has been deleted, so check "{}" has been deactivated. '
+                                              'If you would like to keep the check, re-enable it with '
+                                              'auto_sync: False.'
+                                              .format(check.get_url_for_check(),
+                                                      panel.dashboard_uri.split('/')[1],
+                                                      check.name),
+                                              check.name))
+
+
+def _panel_deleted_handler(check, panel, dashboard_meta):
+    """
+    When a check's panel is deleted in Grafana, deactivate the check and send an email
+    :param check: the status check
+    :param panel: the GrafanaPanel object
+    :param dashboard_meta: "meta" section of Grafana dashboard api response
+    :return None
+    """
+    check.active = False
+    check.save()
+    send_grafana_sync_email.apply_async(args=([str(check.created_by.email), str(dashboard_meta['createdBy']),
+                                               str(dashboard_meta['updatedBy'])],
+                                              '{}\n\n'
+                                              'Panel {} in dashboard "{}" has been deleted, so check "{}" has been '
+                                              'deactivated. If you would like to keep the check, re-enable it with '
+                                              'auto_sync: False.'.format(check.get_url_for_check(),
+                                                                         panel.panel_id,
+                                                                         panel.dashboard_uri.split('/')[1],
+                                                                         check.name),
+                                              check.name))
+
+
+@task(ignore_result=True)
+def sync_all_grafana_checks():
+    """Task to sync all status checks with auto_sync set to their Grafana dashbaords"""
+    sync_time = datetime.now()
+    for check in MetricsStatusCheckBase.objects.filter(auto_sync=True).filter(active=True)\
+            .exclude(grafana_panel__isnull=True):
+        sync_grafana_check.apply_async(args=(check.id, str(sync_time)))
+
+
+@task(ignore_result=True)
+def sync_grafana_check(check_id, sync_time):
+    """
+    Sync a check to a dashboard (sync fields: name, data source, series, ES queries)
+    :param check_id: id of the status check
+    :param sync_time: time the sync started (will check if there were changes before this time)
+    :return None
+    """
+    check = MetricsStatusCheckBase.objects.get(id=check_id)
+    panel = check.grafana_panel
+    grafana_instance = panel.grafana_instance
+
+    try:
+        dashboard_info = get_dashboard_info(grafana_instance, panel.dashboard_uri)
+    except ValidationError:
+        # Dashboard does not exist--deactive check
+        _dashboard_deleted_handler(check, panel)
+        return
+
+    last_updated = get_updated_datetime(dashboard_info)
+    sync_time = datetime.strptime(sync_time, '%Y-%m-%d %H:%M:%S.%f')
+
+    # Check if the dashboard has been updated since the last sync_grafana_check ran
+    if sync_time - last_updated < timedelta(minutes=GRAFANA_SYNC_TIMEDELTA_MINUTES):
+        # Check if anything relevant to the check is changed
+        try:
+            panel_info = get_panel_info(dashboard_info, panel.panel_id)
+        except ValidationError:
+            # Panel does not exist--deactivate check
+            _panel_deleted_handler(check, panel, dashboard_info['meta'])
+            return
+
+        templating_dict = create_generic_templating_dict(dashboard_info)
+
+        context_dict = dict()
+        changed_message = []
+
+        # Check name parity
+        name = template_response(panel_info['title'], templating_dict)
+        # Save old name to use in the email
+        old_name = check.name
+        if name != old_name:
+            changed_message.append(NAME_CHANGED)
+            context_dict['old_name'] = old_name
+            context_dict['new_name'] = name
+            check.name = name
+            check.save()
+
+        # Check datasource parity
+        source_name = panel_info.get('datasource') or 'default'
+        old_source_possibilities = [source.grafana_source_name for source in
+                                    GrafanaDataSource.objects.filter(metrics_source_base=check.source)]
+        if source_name not in old_source_possibilities:
+            context_dict['old_source'] = ' or '.join(old_source_possibilities)
+            context_dict['new_source'] = source_name
+
+            if GrafanaDataSource.objects.filter(grafana_source_name=source_name).exists():
+                changed_message.append(SOURCE_CHANGED_EXISTING)
+                source = GrafanaDataSource.objects.get(grafana_source_name=source_name)
+                check.source = source
+                check.save()
+            else:
+                changed_message.append(SOURCE_CHANGED_NONEXISTING)
+
+        # Check series parity
+        series_ids = get_series_ids(panel_info)
+        if series_ids != panel.series_ids:
+            context_dict['old_series'] = panel.series_ids
+            context_dict['new_series'] = series_ids
+            changed_message.append(SERIES_CHANGED)
+            panel.series_ids = series_ids
+            panel.save()
+
+        # Check Elasticsearch query parity (if it's an Elasticsearch status check)
+        if ElasticsearchStatusCheck.objects.filter(id=check_id).exists():
+            queries = json.dumps(
+                get_es_status_check_fields(dashboard_info, panel_info, panel.selected_series)['queries'])
+            if check.queries != queries:
+                context_dict['old_queries'] = str(check.queries)
+                context_dict['new_queries'] = str(queries)
+                changed_message.append(ES_QUERIES_CHANGED)
+                check.queries = queries
+                check.save()
+
+        # If anything has changed, send an email!
+        if changed_message != []:
+            context = Context(context_dict)
+            template = Template('{}\n\n{}'.format(check.get_url_for_check(), '\n\n'.join(changed_message)))
+
+            email_list = []
+            if check.created_by is not None:
+                email_list.append(str(check.created_by.email))
+
+            # Only email grafana dashboard creator and updater if they're Cabot users
+            dashboard_meta = dashboard_info['meta']
+            for email in [str(dashboard_meta['createdBy']), str(dashboard_meta['updatedBy'])]:
+                if User.objects.filter(email=email).exists():
+                    email_list.append(email)
+
+            send_grafana_sync_email.apply_async(args=(email_list, template.render(context), old_name))
+
+
+@task(ignore_result=True)
+def send_grafana_sync_email(emails, message, check_name):
+    """
+    Send an email about a dashboard being updated from Grafana
+    :param emails: list of emails to send to
+    :param message: message listing the changes
+    :param check_name: name of the status check
+    :return None
+    """
+    send_mail(subject='Cabot check {} changed due to Grafana dashboard update'.format(check_name),
+              message=message,
+              from_email='Cabot Updates<{}>'.format(os.environ.get('CABOT_FROM_EMAIL')),
+              recipient_list=emails)

--- a/cabot/metricsapp/templates.py
+++ b/cabot/metricsapp/templates.py
@@ -1,0 +1,12 @@
+NAME_CHANGED = 'The check name has changed from "{{ old_name }}" to "{{ new_name }}".'
+
+SOURCE_CHANGED_EXISTING = 'The Grafana data source has changed from "{{ old_source }}" to "{{ new_source }}".'
+
+SOURCE_CHANGED_NONEXISTING = SOURCE_CHANGED_EXISTING + ' The new source is not configured in Cabot, so the status ' \
+                                                       'check will continue to use the old source.'
+
+SERIES_CHANGED = 'The panel series ids have changed from {{ old_series }} to {{ new_series }}. ' \
+                 'The check has not been changed.'
+
+ES_QUERIES_CHANGED = 'The queries have changed from\n{% autoescape off %}{{ old_queries }}\nto\n{{ new_queries }}' \
+                     '{% endautoescape %}.'

--- a/cabot/metricsapp/tests/fixtures/elastic/grafana/templating/templating_info.json
+++ b/cabot/metricsapp/tests/fixtures/elastic/grafana/templating/templating_info.json
@@ -15,7 +15,6 @@
           "multi": true,
           "name": "event_name",
           "options": [
-            
           ],
           "query": "{\"find\": \"terms\", \"field\": \"module\", \"query\": \"name:request.body.event_name:*\"}",
           "refresh": 1,
@@ -23,7 +22,6 @@
           "sort": 0,
           "tagValuesQuery": "",
           "tags": [
-            
           ],
           "tagsQuery": "",
           "type": "query",
@@ -167,7 +165,7 @@
           "sort": 1,
           "tagValuesQuery": "",
           "tags": [
-            
+
           ],
           "tagsQuery": "",
           "type": "query",
@@ -176,7 +174,7 @@
         {
           "datasource": "ds",
           "filters": [
-            
+
           ],
           "hide": 0,
           "label": "Ad-hoc Filters",

--- a/cabot/metricsapp/tests/fixtures/grafana/dashboard_detail_response.json
+++ b/cabot/metricsapp/tests/fixtures/grafana/dashboard_detail_response.json
@@ -9,8 +9,8 @@
     "expires": "0004-03-03T00:00:00Z",
     "created": "2013-01-24T00:00:00Z",
     "updated": "2017-02-01T00:00:00Z",
-    "updatedBy": "admin",
-    "createdBy": "admin",
+    "updatedBy": "enduser@affirm.com",
+    "createdBy": "admin@affirm.com",
     "version": 513 
   },
   "dashboard": {

--- a/cabot/metricsapp/tests/test_elasticsearch.py
+++ b/cabot/metricsapp/tests/test_elasticsearch.py
@@ -42,6 +42,12 @@ class TestElasticsearchSource(TestCase):
         self.assertNotIn(' globalhost', repr(client))
 
 
+def get_content(filename):
+    path = os.path.join(os.path.dirname(__file__), 'fixtures/elastic/{}'.format(filename))
+    with open(path) as f:
+        return f.read()
+
+
 def empty_es_response(*args):
     return Response(Search(), [])
 

--- a/cabot/metricsapp/tests/test_grafana.py
+++ b/cabot/metricsapp/tests/test_grafana.py
@@ -1,10 +1,15 @@
 import json
 import os
+from datetime import datetime
+from django.contrib.auth.models import User
+from django.core.exceptions import ValidationError
 from django.test import TestCase
 from mock import patch
 from cabot.metricsapp.api import get_dashboard_choices, get_panel_choices, create_generic_templating_dict, \
-    get_series_choices, get_status_check_fields, get_panel_url
-from cabot.metricsapp.models import GrafanaInstance
+    get_series_choices, get_status_check_fields, get_panel_url, get_series_ids, get_updated_datetime, get_panel_info
+from cabot.metricsapp.models import ElasticsearchStatusCheck, ElasticsearchSource, GrafanaDataSource, \
+    GrafanaInstance, GrafanaPanel
+from cabot.metricsapp.tasks import sync_grafana_check, sync_all_grafana_checks
 
 
 def get_json_file(file):
@@ -97,7 +102,7 @@ class TestGrafanaApiParsing(TestCase):
         for row in self.dashboard_info['dashboard']['rows']:
             for panel in row['panels']:
                 status_check_fields.append(get_status_check_fields(self.dashboard_info, panel, 1, 'datasource',
-                                                                   self.templating_dict))
+                                                                   self.templating_dict, 1))
 
         expected_fields = [
             dict(name='42',
@@ -105,18 +110,35 @@ class TestGrafanaApiParsing(TestCase):
                  time_range=180,
                  high_alert_value=1.0,
                  check_type='>',
+                 grafana_panel=1,
                  warning_value=0.0),
             dict(name='Pct 75',
                  source_info=dict(grafana_source_name='datasource', grafana_instance_id=1),
                  time_range=180,
                  warning_value=100.0,
+                 grafana_panel=1,
                  check_type='<'),
             dict(name='Panel 106',
                  source_info=dict(grafana_source_name='datasource', grafana_instance_id=1),
+                 grafana_panel=1,
                  time_range=180)
         ]
 
         self.assertEqual(status_check_fields, expected_fields)
+
+    def test_get_series_ids(self):
+        series1 = get_series_ids(get_panel_info(self.dashboard_info, 1))
+        self.assertEqual(series1, 'B')
+
+        series5 = get_series_ids(get_panel_info(self.dashboard_info, 5))
+        self.assertEqual(series5, 'A')
+
+        series3 = get_series_ids(get_panel_info(self.dashboard_info, 3))
+        self.assertEqual(series3, 'B')
+
+    def test_get_updated_datetime(self):
+        time = get_updated_datetime(self.dashboard_info)
+        self.assertEqual(time, datetime(2017, 2, 1, 0, 0, 0))
 
 
 class TestGrafanaApiRequests(TestCase):
@@ -145,3 +167,184 @@ class TestPanelUrl(TestCase):
 
         self.assertEqual(panel_url, 'https://grafana-site.com/dashboard-solo/db/dddashboard?panelId=1'
                                     '&var-percentile_1=75&var-group_by=1m&var-module=module')
+
+
+def fake_get_dashboard_info(*args):
+    return get_json_file('dashboard_detail_response.json')
+
+
+def raise_validation_error(*args):
+    raise ValidationError('you did bad')
+
+
+class TestDashboardSync(TestCase):
+    def setUp(self):
+        self.source = ElasticsearchSource.objects.create(
+            name='hi',
+            urls='localhost'
+        )
+        self.grafana_instance = GrafanaInstance.objects.create(
+            name='graf',
+            url='graf',
+            api_key='graf'
+        )
+        self.grafana_data_source = GrafanaDataSource.objects.create(
+            grafana_source_name='deep-thought',
+            grafana_instance=self.grafana_instance,
+            metrics_source_base=self.source
+        )
+        user = User.objects.create_user('hi', email='hi@affirm.com')
+        User.objects.create_user('admin', email='admin@affirm.com')
+        User.objects.create_user('user', email='enduser@affirm.com')
+        self.panel = GrafanaPanel.objects.create(
+            grafana_instance=self.grafana_instance,
+            panel_id=1,
+            dashboard_uri='db/42',
+            series_ids='B',
+            selected_series='B'
+        )
+        self.queries = json.dumps([{'query': {'bool': {'must': [{'query_string':
+                                                                     {'analyze_wildcard': True,
+                                                                      'query':
+                                                                          u'query:life-the-universe-and-everything'}},
+                                                                {'range': {u'@timestamp': {'gte': u'now-3h'}}}]}},
+                                    'aggs': {'agg': {'date_histogram': {'field': u'@timestamp', 'interval': u'1m',
+                                                                        'extended_bounds':
+                                                                            {'max': 'now', 'min': u'now-3h'}},
+                                                     'aggs': {u'sum': {'sum': {'field': u'value'}}}}}}])
+        self.check = ElasticsearchStatusCheck.objects.create(
+            name='42',
+            created_by=user,
+            source=self.source,
+            check_type='>',
+            warning_value=0,
+            high_alert_importance='ERROR',
+            high_alert_value=1,
+            queries=self.queries,
+            time_range=180,
+            grafana_panel=self.panel,
+            auto_sync=True
+        )
+
+    @patch('cabot.metricsapp.tasks.get_dashboard_info', fake_get_dashboard_info)
+    @patch('cabot.metricsapp.tasks.send_grafana_sync_email.apply_async')
+    def test_dashboard_not_updated_time(self, send_email):
+        sync_grafana_check(self.check.id, str(datetime(2017, 3, 1, 0, 0, 0, 1231)))
+        # No emails should be sent since it hasn't been updated recently
+        self.assertFalse(send_email.called)
+
+    @patch('cabot.metricsapp.tasks.get_dashboard_info', fake_get_dashboard_info)
+    @patch('cabot.metricsapp.tasks.send_grafana_sync_email.apply_async')
+    def test_dashboard_no_changes(self, send_email):
+        sync_grafana_check(self.check.id, str(datetime(2017, 2, 1, 0, 0, 1, 123)))
+        # No emails should be sent since nothing relevant in the dashboard has changed
+        self.assertFalse(send_email.called)
+
+    @patch('cabot.metricsapp.tasks.get_dashboard_info', fake_get_dashboard_info)
+    @patch('cabot.metricsapp.tasks.sync_grafana_check.apply_async')
+    def test_no_grafana_panel(self, sync_check):
+        """We don't check checks without associated Grafana panels"""
+        self.check.grafana_panel = None
+        self.check.save()
+        sync_all_grafana_checks()
+        self.assertFalse(sync_check.called)
+
+    @patch('cabot.metricsapp.tasks.get_dashboard_info', fake_get_dashboard_info)
+    @patch('cabot.metricsapp.tasks.send_grafana_sync_email.apply_async')
+    def test_change_panel_name(self, send_email):
+        self.check.name = '44'
+        self.check.save()
+
+        sync_grafana_check(self.check.id, str(datetime(2017, 2, 1, 0, 0, 1, 1231)))
+        send_email.assert_called_once_with(args=(['hi@affirm.com', 'admin@affirm.com', 'enduser@affirm.com'],
+                                                 'http://localhost/check/{}/\n\n'
+                                                 'The check name has changed from "44" to "42".'.format(self.check.id),
+                                                 '44'))
+        self.assertEqual(ElasticsearchStatusCheck.objects.get(id=self.check.id).name, '42')
+
+    @patch('cabot.metricsapp.tasks.get_dashboard_info', fake_get_dashboard_info)
+    @patch('cabot.metricsapp.tasks.send_grafana_sync_email.apply_async')
+    def test_change_datasource(self, send_email):
+        self.grafana_data_source.grafana_source_name = 'hello'
+        self.grafana_data_source.save()
+
+        sync_grafana_check(self.check.id, str(datetime(2017, 2, 1, 0, 0, 1, 231)))
+        send_email.assert_called_once_with(args=(['hi@affirm.com', 'admin@affirm.com', 'enduser@affirm.com'],
+                                                 'http://localhost/check/{}/\n\n'
+                                                 'The Grafana data source has changed from "hello" to "deep-thought". '
+                                                 'The new source is not configured in Cabot, so the status check will '
+                                                 'continue to use the old source.'.format(self.check.id), '42'))
+
+    @patch('cabot.metricsapp.tasks.get_dashboard_info', fake_get_dashboard_info)
+    @patch('cabot.metricsapp.tasks.send_grafana_sync_email.apply_async')
+    def test_change_series_ids(self, send_email):
+        self.panel.series_ids = 'B,E'
+        self.panel.save()
+
+        sync_grafana_check(self.check.id, str(datetime(2017, 2, 1, 0, 0, 1, 12)))
+        send_email.assert_called_once_with(args=(['hi@affirm.com', 'admin@affirm.com', 'enduser@affirm.com'],
+                                                 'http://localhost/check/{}/\n\n'
+                                                 'The panel series ids have changed from B,E to B. The check has not '
+                                                 'been changed.'.format(self.check.id), '42'))
+        self.assertEqual(GrafanaPanel.objects.get(id=self.panel.id).series_ids, 'B')
+
+    @patch('cabot.metricsapp.tasks.get_dashboard_info', fake_get_dashboard_info)
+    @patch('cabot.metricsapp.tasks.send_grafana_sync_email.apply_async')
+    def test_change_queries(self, send_email):
+        self.check.queries = 'to-be-or-not-to-be'
+        self.check.save()
+
+        sync_grafana_check(self.check.id, str(datetime(2017, 2, 1, 0, 0, 1, 123)))
+        send_email.assert_called_once_with(args=(['hi@affirm.com', 'admin@affirm.com', 'enduser@affirm.com'],
+                                                 'http://localhost/check/{}/\n\n'
+                                                 'The queries have changed from\nto-be-or-not-to-be\nto\n{}.'.format(
+                                                     self.check.id, str(self.queries)
+                                                 ), '42'))
+        self.assertEqual(ElasticsearchStatusCheck.objects.get(id=self.check.id).queries, str(self.queries))
+
+    @patch('cabot.metricsapp.tasks.get_dashboard_info', fake_get_dashboard_info)
+    @patch('cabot.metricsapp.tasks.send_grafana_sync_email.apply_async')
+    def test_change_multiple(self, send_email):
+        self.check.name = 'goodbye'
+        self.check.queries = 'to-be-or-not-to-be'
+        self.check.save()
+
+        sync_grafana_check(self.check.id, str(datetime(2017, 2, 1, 0, 0, 1, 12312)))
+        send_email.assert_called_once_with(args=(['hi@affirm.com', 'admin@affirm.com', 'enduser@affirm.com'],
+                                                 'http://localhost/check/{}/\n\n'
+                                                 'The check name has changed from "goodbye" to "42".\n\n'
+                                                 'The queries have changed from\nto-be-or-not-to-be\nto\n{}.'.format(
+                                                     self.check.id, str(self.queries)
+                                                 ), 'goodbye'))
+        check = ElasticsearchStatusCheck.objects.get(id=self.check.id)
+        self.assertEqual(check.name, '42')
+        self.assertEqual(check.queries, str(self.queries))
+
+    @patch('cabot.metricsapp.tasks.get_dashboard_info', raise_validation_error)
+    @patch('cabot.metricsapp.tasks.send_grafana_sync_email.apply_async')
+    def test_dashboard_deleted(self, send_email):
+        sync_grafana_check(self.check.id, str(datetime(2017, 2, 1, 0, 0, 1, 1231)))
+        send_email.assert_called_once_with(args=(['hi@affirm.com'],
+                                                 'http://localhost/check/{}/\n\n'
+                                                 'Dashboard "{}" has been deleted, so check "{}" has been '
+                                                 'deactivated. If you would like to keep the check, re-enable it '
+                                                 'with auto_sync: False.'
+                                                 .format(self.check.id, '42', '42'),
+                                                 '42'))
+        check = ElasticsearchStatusCheck.objects.get(id=self.check.id)
+        self.assertFalse(check.active)
+
+    @patch('cabot.metricsapp.tasks.get_dashboard_info', fake_get_dashboard_info)
+    @patch('cabot.metricsapp.tasks.get_panel_info', raise_validation_error)
+    @patch('cabot.metricsapp.tasks.send_grafana_sync_email.apply_async')
+    def test_panel_deleted(self, send_email):
+        sync_grafana_check(self.check.id, str(datetime(2017, 2, 1, 0, 0, 1, 12321)))
+        send_email.assert_called_once_with(args=(['hi@affirm.com', 'admin@affirm.com', 'enduser@affirm.com'],
+                                                 'http://localhost/check/{}/\n\n'
+                                                 'Panel {} in dashboard "{}" has been deleted, so check "{}" has been '
+                                                 'deactivated. If you would like to keep the check, re-enable it with '
+                                                 'auto_sync: False.'.format(self.check.id, '1', '42', '42'),
+                                                 '42'))
+
+        check = ElasticsearchStatusCheck.objects.get(id=self.check.id)
+        self.assertFalse(check.active)

--- a/cabot/metricsapp/views/grafana_elastic.py
+++ b/cabot/metricsapp/views/grafana_elastic.py
@@ -19,9 +19,10 @@ class GrafanaElasticsearchStatusCheckCreateView(LoginRequiredMixin, View):
         series = request.session['series']
         datasource = request.session['datasource']
         templating_dict = request.session['templating_dict']
+        grafana_panel = request.session['grafana_panel']
 
         form = self.form_class(fields=get_status_check_fields(dashboard_info, panel_info, instance_id,
-                                                              datasource, templating_dict),
+                                                              datasource, templating_dict, grafana_panel),
                                es_fields=get_es_status_check_fields(dashboard_info, panel_info, series))
 
         panel_url = get_panel_url(GrafanaInstance.objects.get(id=instance_id).url,
@@ -38,10 +39,11 @@ class GrafanaElasticsearchStatusCheckCreateView(LoginRequiredMixin, View):
         series = request.session['series']
         datasource = request.session['datasource']
         templating_dict = request.session['templating_dict']
+        grafana_panel = request.session['grafana_panel']
 
         form = self.form_class(request.POST,
                                fields=get_status_check_fields(dashboard_info, panel_info, instance_id,
-                                                              datasource, templating_dict),
+                                                              datasource, templating_dict, grafana_panel),
                                es_fields=get_es_status_check_fields(dashboard_info, panel_info, series))
 
         if form.is_valid() and not form.errors:


### PR DESCRIPTION
Ready for review please!

- New model (GrafanaPanel) for keeping track of info in the Grafana panel for each check (created in status check creation flow)
- New field "auto_sync" in status check to indicate whether we should try to sync the check with changes in the Grafana dashboard
- Celery task for syncing checks who's dashboard has changed w/in the past 60 minutes and sending emails to the check creator, dashboard creator, and dashboard updater
- Tests for new api functions and celery task

Changes for this PR only are in https://github.com/Affirm/cabot/pull/47/commits/0e6092020d530141a4698ae800d9a3cdb080e41b, it's on top of #46 since it uses the same test fixtures