### PR TITLE
Make name field editable

### DIFF
--- a/cabot/metricsapp/api/grafana.py
+++ b/cabot/metricsapp/api/grafana.py
@@ -182,7 +182,8 @@ def get_status_check_fields(dashboard_info, panel_info, grafana_data_source, tem
     """
     fields = {}
 
-    fields['name'] = template_response(panel_info['title'], templating_dict)
+    name = '{}: {}'.format(dashboard_info['dashboard']['title'], panel_info['title'])
+    fields['name'] = template_response(name, templating_dict)
     fields['source'] = grafana_data_source.metrics_source_base
 
     # Earliest time should be formatted "now-3h", all other formats will be ignored

--- a/cabot/metricsapp/forms/grafana.py
+++ b/cabot/metricsapp/forms/grafana.py
@@ -108,7 +108,7 @@ class GrafanaStatusCheckForm(StatusCheckForm):
         self.fields['name'].initial = fields['name']
 
         # Hide name field so users can't edit it.
-        self.fields['name'].widget = forms.TextInput(attrs=dict(readonly='readonly', style='width:50%'))
+        self.fields['name'].widget = forms.TextInput(attrs=dict(style='width:50%'))
         self.fields['name'].help_text = None
 
         # Time range, check_type, and thresholds are editable.
@@ -141,4 +141,4 @@ class GrafanaStatusCheckUpdateForm(StatusCheckForm):
     def __init__(self, *args, **kwargs):
         super(GrafanaStatusCheckUpdateForm, self).__init__(*args, **kwargs)
         # Hide name field
-        self.fields['name'].widget = forms.TextInput(attrs=dict(readonly='readonly', style='width:50%'))
+        self.fields['name'].widget = forms.TextInput(attrs=dict(style='width:50%'))

--- a/cabot/metricsapp/tests/test_grafana.py
+++ b/cabot/metricsapp/tests/test_grafana.py
@@ -108,7 +108,7 @@ class TestGrafanaApiParsing(TestCase):
                                                                    self.templating_dict, 1))
 
         expected_fields = [
-            dict(name='42',
+            dict(name='Also Great Dashboard: 42',
                  source='datasource',
                  time_range=180,
                  high_alert_value=1.0,
@@ -116,14 +116,14 @@ class TestGrafanaApiParsing(TestCase):
                  grafana_panel=1,
                  warning_value=0.0,
                  user=None),
-            dict(name='Pct 75',
+            dict(name='Also Great Dashboard: Pct 75',
                  source='datasource',
                  time_range=180,
                  warning_value=100.0,
                  grafana_panel=1,
                  check_type='<',
                  user=None),
-            dict(name='Panel 106',
+            dict(name='Also Great Dashboard: Panel 106',
                  source='datasource',
                  grafana_panel=1,
                  time_range=180,


### PR DESCRIPTION
Reasons:
 - Grafana dashboard names ("Error Count") don't always give much info
 - We can have multiple checks per panel w/ different series and it'd be helpful to differentiate