### PR TITLE
Bugfixes for "all" query and update task

### DIFF
--- a/cabot/metricsapp/api/__init__.py
+++ b/cabot/metricsapp/api/__init__.py
@@ -5,4 +5,4 @@ from .grafana_elastic import build_query, template_response, create_elasticsearc
 from .grafana import get_dashboards, get_dashboard_choices, get_dashboard_info, \
     get_panel_choices, get_series_choices, template_response, create_generic_templating_dict, \
     get_status_check_fields, get_panel_url, get_updated_datetime, get_panel_info, get_series_ids, \
-    get_time_range
+    get_time_range, get_status_check_name

--- a/cabot/metricsapp/api/grafana.py
+++ b/cabot/metricsapp/api/grafana.py
@@ -190,6 +190,18 @@ def get_time_range(dashboard_info, panel_info):
     return None
 
 
+def get_status_check_name(dashboard_info, panel_info, templating_dict):
+    """
+    Create the name for a status check: 'Dashboard name: panel name'
+    :param dashboard_info: Grafana API dashboard info
+    :param panel_info: Grafana API panel info
+    :param templating_dict: dictionary of {template_name, template_value}
+    :return: the name for the related status check
+    """
+    name = '{}: {}'.format(dashboard_info['dashboard']['title'], panel_info['title'])
+    return template_response(name, templating_dict)
+
+
 def get_status_check_fields(dashboard_info, panel_info, grafana_data_source, templating_dict,
                             grafana_panel, user=None):
     """
@@ -197,15 +209,14 @@ def get_status_check_fields(dashboard_info, panel_info, grafana_data_source, tem
     :param dashboard_info: Grafana API dashboard info
     :param panel_info: Grafana API panel info
     :param grafana_instance_id: ID of the Grafana instance used
-    :param templating_dict: dictionary of {template_name, template _value}
+    :param templating_dict: dictionary of {template_name, template_value}
     :param grafana_panel: GrafanaPanel object id
     :param user: user who created the check
     :return: dictionary containing StatusCheck field names and values
     """
     fields = {}
 
-    name = '{}: {}'.format(dashboard_info['dashboard']['title'], panel_info['title'])
-    fields['name'] = template_response(name, templating_dict)
+    fields['name'] = get_status_check_name(dashboard_info, panel_info, templating_dict)
     fields['source'] = grafana_data_source.metrics_source_base
 
     time_range = get_time_range(dashboard_info, panel_info)

--- a/cabot/metricsapp/api/grafana_elastic.py
+++ b/cabot/metricsapp/api/grafana_elastic.py
@@ -198,7 +198,11 @@ def create_elasticsearch_templating_dict(dashboard_info):
         # Multi-valued templates are surrounded by parentheses and combined with OR
         if '$__all' in template_value:
             options = [option['value'] for option in template['options']]
-            templates[template_name] = '({})'.format(' OR '.join(options))
+            # If there aren't any options, fall back to selecting everything
+            if options == []:
+                templates[template_name] = '*'
+            else:
+                templates[template_name] = '({})'.format(' OR '.join(options))
 
         elif isinstance(template_value, list):
             templates[template_name] = '({})'.format(' OR '.join(template_value))

--- a/cabot/metricsapp/tasks.py
+++ b/cabot/metricsapp/tasks.py
@@ -8,7 +8,8 @@ from django.core.exceptions import ValidationError
 from django.core.mail import send_mail
 from django.template import Context, Template
 from cabot.metricsapp.api import get_dashboard_info, get_updated_datetime, get_panel_info, \
-    create_generic_templating_dict, template_response, get_es_status_check_fields, get_series_ids
+    create_generic_templating_dict, get_es_status_check_fields, get_series_ids, \
+    get_status_check_name
 from cabot.metricsapp.defs import GRAFANA_SYNC_TIMEDELTA_MINUTES
 from cabot.metricsapp.models import MetricsStatusCheckBase, ElasticsearchStatusCheck, GrafanaDataSource
 from cabot.metricsapp.templates import NAME_CHANGED, SOURCE_CHANGED_EXISTING, SOURCE_CHANGED_NONEXISTING, \
@@ -107,7 +108,7 @@ def sync_grafana_check(check_id, sync_time):
         changed_message = []
 
         # Check name parity
-        name = template_response(panel_info['title'], templating_dict)
+        name = get_status_check_name(dashboard_info, panel_info, templating_dict)
         # Save old name to use in the email
         old_name = check.name
         if name != old_name:

--- a/cabot/metricsapp/tests/test_grafana.py
+++ b/cabot/metricsapp/tests/test_grafana.py
@@ -221,7 +221,7 @@ class TestDashboardSync(TestCase):
                            '"extended_bounds": {"max": "now", "min": "now-3h"}}, ' \
                            '"aggs": {"sum": {"sum": {"field": "count"}}}}}}}}]'
         self.check = ElasticsearchStatusCheck.objects.create(
-            name='42',
+            name='Also Great Dashboard: 42',
             created_by=user,
             source=self.source,
             check_type='>',
@@ -266,9 +266,9 @@ class TestDashboardSync(TestCase):
         sync_grafana_check(self.check.id, str(datetime(2017, 2, 1, 0, 0, 1, 1231)))
         send_email.assert_called_once_with(args=(['hi@affirm.com', 'admin@affirm.com', 'enduser@affirm.com'],
                                                  'http://localhost/check/{}/\n\n'
-                                                 'The check name has changed from "44" to "42".'.format(self.check.id),
-                                                 '44'))
-        self.assertEqual(ElasticsearchStatusCheck.objects.get(id=self.check.id).name, '42')
+                                                 'The check name has changed from "44" to "Also Great Dashboard: 42".'
+                                                 .format(self.check.id), '44'))
+        self.assertEqual(ElasticsearchStatusCheck.objects.get(id=self.check.id).name, 'Also Great Dashboard: 42')
 
     @patch('cabot.metricsapp.tasks.get_dashboard_info', fake_get_dashboard_info)
     @patch('cabot.metricsapp.tasks.send_grafana_sync_email.apply_async')
@@ -281,7 +281,8 @@ class TestDashboardSync(TestCase):
                                                  'http://localhost/check/{}/\n\n'
                                                  'The Grafana data source has changed from "hello" to "deep-thought". '
                                                  'The new source is not configured in Cabot, so the status check will '
-                                                 'continue to use the old source.'.format(self.check.id), '42'))
+                                                 'continue to use the old source.'.format(self.check.id),
+                                                 'Also Great Dashboard: 42'))
 
     @patch('cabot.metricsapp.tasks.get_dashboard_info', fake_get_dashboard_info)
     @patch('cabot.metricsapp.tasks.send_grafana_sync_email.apply_async')
@@ -293,7 +294,7 @@ class TestDashboardSync(TestCase):
         send_email.assert_called_once_with(args=(['hi@affirm.com', 'admin@affirm.com', 'enduser@affirm.com'],
                                                  'http://localhost/check/{}/\n\n'
                                                  'The panel series ids have changed from B,E to B. The check has not '
-                                                 'been changed.'.format(self.check.id), '42'))
+                                                 'been changed.'.format(self.check.id), 'Also Great Dashboard: 42'))
         self.assertEqual(GrafanaPanel.objects.get(id=self.panel.id).series_ids, 'B')
 
     @patch('cabot.metricsapp.tasks.get_dashboard_info', fake_get_dashboard_info)
@@ -307,7 +308,7 @@ class TestDashboardSync(TestCase):
                                                  'http://localhost/check/{}/\n\n'
                                                  'The queries have changed from\n{}\nto\n{}.'.format(
                                                      self.check.id, self.old_queries, self.queries
-                                                 ), '42'))
+                                                 ), 'Also Great Dashboard: 42'))
         self.assertEqual(ElasticsearchStatusCheck.objects.get(id=self.check.id).queries, str(self.queries))
 
     @patch('cabot.metricsapp.tasks.get_dashboard_info', fake_get_dashboard_info)
@@ -320,12 +321,13 @@ class TestDashboardSync(TestCase):
         sync_grafana_check(self.check.id, str(datetime(2017, 2, 1, 0, 0, 1, 12312)))
         send_email.assert_called_once_with(args=(['hi@affirm.com', 'admin@affirm.com', 'enduser@affirm.com'],
                                                  'http://localhost/check/{}/\n\n'
-                                                 'The check name has changed from "goodbye" to "42".\n\n'
+                                                 'The check name has changed from "goodbye" to '
+                                                 '"Also Great Dashboard: 42".\n\n'
                                                  'The queries have changed from\n{}\nto\n{}.'.format(
                                                      self.check.id, self.old_queries, self.queries
                                                  ), 'goodbye'))
         check = ElasticsearchStatusCheck.objects.get(id=self.check.id)
-        self.assertEqual(check.name, '42')
+        self.assertEqual(check.name, 'Also Great Dashboard: 42')
         self.assertEqual(check.queries, str(self.queries))
 
     @patch('cabot.metricsapp.tasks.get_dashboard_info', raise_validation_error)
@@ -337,8 +339,8 @@ class TestDashboardSync(TestCase):
                                                  'Dashboard "{}" has been deleted, so check "{}" has been '
                                                  'deactivated. If you would like to keep the check, re-enable it '
                                                  'with auto_sync: False.'
-                                                 .format(self.check.id, '42', '42'),
-                                                 '42'))
+                                                 .format(self.check.id, '42', 'Also Great Dashboard: 42'),
+                                                 'Also Great Dashboard: 42'))
         check = ElasticsearchStatusCheck.objects.get(id=self.check.id)
         self.assertFalse(check.active)
 
@@ -351,8 +353,9 @@ class TestDashboardSync(TestCase):
                                                  'http://localhost/check/{}/\n\n'
                                                  'Panel {} in dashboard "{}" has been deleted, so check "{}" has been '
                                                  'deactivated. If you would like to keep the check, re-enable it with '
-                                                 'auto_sync: False.'.format(self.check.id, '1', '42', '42'),
-                                                 '42'))
+                                                 'auto_sync: False.'
+                                                 .format(self.check.id, '1', '42', 'Also Great Dashboard: 42'),
+                                                 'Also Great Dashboard: 42'))
 
         check = ElasticsearchStatusCheck.objects.get(id=self.check.id)
         self.assertFalse(check.active)


### PR DESCRIPTION
 - If there aren't any options for all query fall back to "*"
 - update task created status check name differently than in check creation