### PR TITLE
save the service/instance sets when saving GrafanaStatusChecks

### DIFF
--- a/cabot/metricsapp/forms/grafana.py
+++ b/cabot/metricsapp/forms/grafana.py
@@ -133,6 +133,10 @@ class GrafanaStatusCheckForm(StatusCheckForm):
             model.created_by = self.user
 
         model.save()
+
+        # When commit is False, we just get the model, but the service/instance sets aren't saved
+        # (since the model doesn't have a pk yet). Re-run to actually save the service and instance sets
+        model = super(GrafanaStatusCheckForm, self).save()
         return model
 
 


### PR DESCRIPTION
kinda sketchy to save() twice but it works (and I checked that it doesn't duplicate the check or anything)