### PR TITLE
Add $ to the end of urls to prevent incorrect matching

### DIFF
--- a/cabot/urls.py
+++ b/cabot/urls.py
@@ -73,7 +73,7 @@ urlpatterns = patterns(
         view=password_reset_confirm,
         name='password-reset-confirm'),
 
-    url(r'^services/',
+    url(r'^services/$',
         view=ServiceListView.as_view(),
         name='services'),
     url(r'^service/create/',
@@ -142,7 +142,7 @@ urlpatterns = patterns(
     url(r'^result/(?P<pk>\d+)/',
         view=StatusCheckResultDetailView.as_view(),
         name='result'),
-    url(r'^shifts/',
+    url(r'^shifts/$',
         view=ScheduleListView.as_view(),
         name='shifts'),
     url(r'^shifts/(?P<pk>\d+)/',


### PR DESCRIPTION
@aaronabf I deployed your changes to stage when I was testing something out, and found that the shift list page wasn't working because the url order was changed in the flake8 PR. 

Previously we had
```
url(r'^shifts/((?P<pk>\d+)/',...,
url(r'^shifts/',...
```
and the order was switched. So when we redirected people to shifts/1/ to view the first url, the first URL match was /shifts/ instead of /shifts/(...pk...), so they were sent to the /shifts/ page instead of the /shifts/1 page. I added a $ (end of string character) at the end so that url will only match /shifts/ exactly. 

Tagging you in this cuz I wanted to give you more context about how django urls work. More info here: https://docs.djangoproject.com/en/1.11/topics/http/urls/