### PR TITLE
Change broker to rabbitmq in docker-compose and make celery beat work in test site

### DIFF
--- a/conf/development.env.example
+++ b/conf/development.env.example
@@ -22,7 +22,7 @@ CABOT_FROM_EMAIL=cabot@example.com
 # CALENDAR_ICAL_URL=http://www.google.com/calendar/ical/example.ics
 
 # Django settings
-CELERY_BROKER_URL=redis://redis:6379/1
+CELERY_BROKER_URL=amqp://rabbitmq:5672
 DJANGO_SECRET_KEY=2FL6ORhHwr5eX34pP9mMugnIOd3jzVuT45f7w430Mt5PnEwbcJgma0q8zUXNZ68A
 
 # Hostname of your Graphite server instance
@@ -67,7 +67,7 @@ AUTH_LDAP_BIND_DN="cn=Manager,dc=example,dc=com"
 AUTH_LDAP_BIND_PASSWORD=""
 AUTH_LDAP_USER_SEARCH="ou=People,dc=example,dc=com"
 
-CELERY_RATE_LIMIT='15/s'
+CELERY_RATE_LIMIT=15/s
 
 TEST_OUTPUT_DIR=./build/test-psql
 DISABLE_LOGIN=True

--- a/conf/mysql.env.example
+++ b/conf/mysql.env.example
@@ -22,7 +22,7 @@ CABOT_FROM_EMAIL=cabot@example.com
 # CALENDAR_ICAL_URL=http://www.google.com/calendar/ical/example.ics
 
 # Django settings
-CELERY_BROKER_URL=redis://redis:6379/1
+CELERY_BROKER_URL=amqp://rabbitmq:5672
 DJANGO_SECRET_KEY=2FL6ORhHwr5eX34pP9mMugnIOd3jzVuT45f7w430Mt5PnEwbcJgma0q8zUXNZ68A
 
 # Hostname of your Graphite server instance
@@ -67,7 +67,7 @@ AUTH_LDAP_BIND_DN="cn=Manager,dc=example,dc=com"
 AUTH_LDAP_BIND_PASSWORD=""
 AUTH_LDAP_USER_SEARCH="ou=People,dc=example,dc=com"
 
-CELERY_RATE_LIMIT='15/s'
+CELERY_RATE_LIMIT=15/s
 
 TEST_OUTPUT_DIR=./build/test-mysql
 DISABLE_LOGIN=True

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,7 +11,7 @@ services:
     volumes:
      - .:/code
     links:
-     - redis
+     - rabbitmq
      - db_psql
      - db_mysql
 
@@ -19,16 +19,20 @@ services:
     env_file:
      - conf/development.env
     image: cabot:web
-    command: python manage.py celery worker -B -A cabot --loglevel=DEBUG --concurrency=16 -Ofair
+    command: bash -euc "dockerize -wait tcp://db_psql:5432 -timeout 60s; dockerize -wait tcp://root:test@db_mysql:3306 -timeout 60s; python manage.py celery worker -B -A cabot --loglevel=DEBUG --concurrency=16 --logfile=/var/log/cabot-celery.log -Ofair"
     volumes:
      - .:/code
     links:
-     - redis
+     - rabbitmq
      - db_psql
      - db_mysql
+    depends_on:
+     - db_psql
+     - db_mysql
+     - rabbitmq
 
-  redis:
-    image: redis
+  rabbitmq:
+    image: rabbitmq
 
   db_psql:
     image: postgres

--- a/tox.ini
+++ b/tox.ini
@@ -38,6 +38,7 @@ commands =
     bash -euc "docker-compose up -d"
     bash -euc "docker-compose run wait_psql"
     bash -euc "docker-compose run --rm web bash bin/build-app"
+    bash -euc "docker-compose run --rm worker python manage.py celery beat -A cabot --detach --pidfile=/var/log/beat.pid"
 
 [testenv:destroy-app]
 commands =
@@ -72,6 +73,4 @@ commands =
     rm -rf build/flake8/
     mkdir -p build/flake8
     bash -euc -o pipefail "flake8 --config=setup.cfg -j 2 --exit-zero {posargs:} | tee build/flake8/flake8.txt"
-    # Fail if there are more than 35 flake8 issues (there were 30 as of 1/12)
-    # We should lower this number!
     bash -euc -o pipefail '(("$(wc -l < build/flake8/flake8.txt)" == 0))'


### PR DESCRIPTION
There were 2 issues with the worker docker service: the CELERY_RATE_LIMIT config was written incorrectly, causing errors, and running celery beat with `celery worker -B` wasn't working. I fixed CELERY_RATE_LIMIT and added a command to build-app to run celery beat (it needs to start running after the app has been built). 

Other changes:

- make the test site use rabbitmq instead of redis for parity with production.
- celery will write to a logfile in the docker container for easier debugging

In my testing, checks are now actually running in the test site :)