### PR TITLE
Send alerts for all schedules together so we don't have duplicate hipchat alerts

### DIFF
--- a/cabot/cabotapp/models.py
+++ b/cabot/cabotapp/models.py
@@ -195,12 +195,12 @@ class CheckGroupMixin(models.Model):
 
         schedules = self.schedules.all()
 
-        if not schedules:
-            send_alert(self)
-
+        duty_officers = []
+        fallback_officers = []
         for schedule in schedules:
-            send_alert(self, duty_officers=get_duty_officers(schedule),
-                       fallback_officers=get_fallback_officers(schedule))
+            duty_officers.extend(get_duty_officers(schedule))
+            fallback_officers.extend(get_fallback_officers(schedule))
+        send_alert(self, duty_officers=duty_officers, fallback_officers=fallback_officers)
 
     @property
     def recent_snapshots(self):

--- a/cabot/cabotapp/tests/test_alerts.py
+++ b/cabot/cabotapp/tests/test_alerts.py
@@ -36,7 +36,7 @@ class TestAlerts(LocalTestCase):
         self.service.schedules = []
         self.service.alert()
         self.assertEqual(fake_send_alert.call_count, 1)
-        fake_send_alert.assert_called_with(self.service)
+        fake_send_alert.assert_called_with(self.service, duty_officers=[], fallback_officers=[])
 
     @patch('cabot.cabotapp.models.send_alert')
     def test_alert_empty_schedule(self, fake_send_alert):
@@ -77,11 +77,9 @@ class TestAlerts(LocalTestCase):
         service.update_status()
 
         service.alert()
-        self.assertEqual(fake_send_alert.call_count, 2)
         # Since there are no duty officers with profiles, the fallback will be alerted
-        calls = [call(service, duty_officers=[self.user], fallback_officers=[self.user]),
-                 call(service, duty_officers=[user], fallback_officers=[user])]
-        fake_send_alert.has_calls(calls)
+        fake_send_alert.assert_called_once_with(service, duty_officers=[self.user, user],
+                                                fallback_officers=[self.user, user])
 
     @patch('cabot.cabotapp.alert.AlertPlugin.send_alert')
     def test_alert_plugin(self, fake_send_alert):


### PR DESCRIPTION
When a service has multiple schedules, Hipchat will send a notification to the room for each schedule, which is confusing/annoying (especially for Warning level alerts which don't tag people--the messages are exactly the same). This will combine everything into one alert