### PR TITLE
Delete removed oncall officers

### DIFF
--- a/cabot/cabotapp/tasks.py
+++ b/cabot/cabotapp/tasks.py
@@ -96,7 +96,6 @@ def update_shifts():
 def reset_shifts(schedule_id):
     try:
         schedule = models.Schedule.objects.get(id=schedule_id)
-        models.delete_shifts(schedule)
         models.update_shifts(schedule)
     except Exception as e:
         logger.exception('Error when resetting shifts: {}'.format(e))


### PR DESCRIPTION
Mark shifts as updated when syncing a schedule, then delete the non-updated shifts for that schedule afterwards (can't delete them before syncing because then we could have a time where no one's oncall).