### PR TITLE
Add run-book notes to cabot.

### DIFF
--- a/cabot/cabotapp/migrations/0032_auto__add_field_statuscheck_runbook.py
+++ b/cabot/cabotapp/migrations/0032_auto__add_field_statuscheck_runbook.py
@@ -1,0 +1,192 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'StatusCheck.runbook'
+        db.add_column(u'cabotapp_statuscheck', 'runbook',
+                      self.gf('django.db.models.fields.TextField')(default=None, null=True, blank=True),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'StatusCheck.runbook'
+        db.delete_column(u'cabotapp_statuscheck', 'runbook')
+
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'cabotapp.alertplugin': {
+            'Meta': {'object_name': 'AlertPlugin'},
+            'enabled': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'polymorphic_ctype': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'polymorphic_cabotapp.alertplugin_set'", 'null': 'True', 'to': u"orm['contenttypes.ContentType']"}),
+            'title': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'cabotapp.alertpluginuserdata': {
+            'Meta': {'unique_together': "(('title', 'user'),)", 'object_name': 'AlertPluginUserData'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'polymorphic_ctype': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'polymorphic_cabotapp.alertpluginuserdata_set'", 'null': 'True', 'to': u"orm['contenttypes.ContentType']"}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '30'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['cabotapp.UserProfile']"})
+        },
+        u'cabotapp.hipchatinstance': {
+            'Meta': {'object_name': 'HipchatInstance'},
+            'api_v2_key': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '20'}),
+            'server_url': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'cabotapp.httpstatuscheck': {
+            'Meta': {'ordering': "['name']", 'object_name': 'HttpStatusCheck', '_ormbases': [u'cabotapp.StatusCheck']},
+            'allow_http_redirects': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'endpoint': ('django.db.models.fields.TextField', [], {'null': 'True'}),
+            'header_match': ('django.db.models.fields.TextField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'http_body': ('django.db.models.fields.TextField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'http_method': ('django.db.models.fields.CharField', [], {'default': "'GET'", 'max_length': '10'}),
+            'http_params': ('django.db.models.fields.TextField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'password': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'status_code': ('django.db.models.fields.TextField', [], {'default': '200', 'null': 'True'}),
+            u'statuscheck_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['cabotapp.StatusCheck']", 'unique': 'True', 'primary_key': 'True'}),
+            'text_match': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'timeout': ('cabot.cabotapp.fields.PositiveIntegerMaxField', [], {'default': '30', 'null': 'True'}),
+            'username': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'verify_ssl_certificate': ('django.db.models.fields.BooleanField', [], {'default': 'True'})
+        },
+        u'cabotapp.jenkinsstatuscheck': {
+            'Meta': {'ordering': "['name']", 'object_name': 'JenkinsStatusCheck', '_ormbases': [u'cabotapp.StatusCheck']},
+            'max_queued_build_time': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            u'statuscheck_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['cabotapp.StatusCheck']", 'unique': 'True', 'primary_key': 'True'})
+        },
+        u'cabotapp.schedule': {
+            'Meta': {'object_name': 'Schedule'},
+            'fallback_officer': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']", 'null': 'True', 'blank': 'True'}),
+            'ical_url': ('django.db.models.fields.TextField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '50'})
+        },
+        u'cabotapp.service': {
+            'Meta': {'ordering': "['name']", 'object_name': 'Service'},
+            'alerts': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['cabotapp.AlertPlugin']", 'symmetrical': 'False', 'blank': 'True'}),
+            'alerts_enabled': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'email_alert': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'hackpad_id': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'hipchat_alert': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'hipchat_instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['cabotapp.HipchatInstance']", 'null': 'True', 'blank': 'True'}),
+            'hipchat_room_id': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_alert_sent': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.TextField', [], {}),
+            'old_overall_status': ('django.db.models.fields.TextField', [], {'default': "'PASSING'"}),
+            'overall_status': ('django.db.models.fields.TextField', [], {'default': "'PASSING'"}),
+            'schedules': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['cabotapp.Schedule']", 'null': 'True', 'blank': 'True'}),
+            'sms_alert': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'status_checks': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['cabotapp.StatusCheck']", 'symmetrical': 'False', 'blank': 'True'}),
+            'telephone_alert': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'url': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'users_to_notify': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.User']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'cabotapp.servicestatussnapshot': {
+            'Meta': {'object_name': 'ServiceStatusSnapshot'},
+            'did_send_alert': ('django.db.models.fields.IntegerField', [], {'default': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'num_checks_active': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'num_checks_failing': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'num_checks_passing': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'overall_status': ('django.db.models.fields.TextField', [], {'default': "'PASSING'"}),
+            'service': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'snapshots'", 'to': u"orm['cabotapp.Service']"}),
+            'time': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True'})
+        },
+        u'cabotapp.shift': {
+            'Meta': {'object_name': 'Shift'},
+            'deleted': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'end': ('django.db.models.fields.DateTimeField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'schedule': ('django.db.models.fields.related.ForeignKey', [], {'default': '1', 'to': u"orm['cabotapp.Schedule']"}),
+            'start': ('django.db.models.fields.DateTimeField', [], {}),
+            'uid': ('django.db.models.fields.TextField', [], {}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']"})
+        },
+        u'cabotapp.statuscheck': {
+            'Meta': {'ordering': "['name']", 'object_name': 'StatusCheck'},
+            'active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'cached_health': ('django.db.models.fields.TextField', [], {'null': 'True'}),
+            'calculated_status': ('django.db.models.fields.CharField', [], {'default': "'passing'", 'max_length': '50', 'blank': 'True'}),
+            'created_by': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']", 'null': 'True'}),
+            'frequency': ('django.db.models.fields.PositiveIntegerField', [], {'default': '5'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'importance': ('django.db.models.fields.CharField', [], {'default': "'ERROR'", 'max_length': '30'}),
+            'last_run': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            'name': ('django.db.models.fields.TextField', [], {}),
+            'polymorphic_ctype': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'polymorphic_cabotapp.statuscheck_set'", 'null': 'True', 'to': u"orm['contenttypes.ContentType']"}),
+            'retries': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0', 'null': 'True'}),
+            'runbook': ('django.db.models.fields.TextField', [], {'default': 'None', 'null': 'True', 'blank': 'True'})
+        },
+        u'cabotapp.statuscheckresult': {
+            'Meta': {'object_name': 'StatusCheckResult'},
+            'check': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['cabotapp.StatusCheck']"}),
+            'error': ('django.db.models.fields.TextField', [], {'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'job_number': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True'}),
+            'raw_data': ('django.db.models.fields.TextField', [], {'null': 'True'}),
+            'succeeded': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'time': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True'}),
+            'time_complete': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'db_index': 'True'})
+        },
+        u'cabotapp.tcpstatuscheck': {
+            'Meta': {'ordering': "['name']", 'object_name': 'TCPStatusCheck', '_ormbases': [u'cabotapp.StatusCheck']},
+            'address': ('django.db.models.fields.CharField', [], {'max_length': '1024'}),
+            'port': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            u'statuscheck_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['cabotapp.StatusCheck']", 'unique': 'True', 'primary_key': 'True'}),
+            'timeout': ('cabot.cabotapp.fields.PositiveIntegerMaxField', [], {'default': '8'})
+        },
+        u'cabotapp.userprofile': {
+            'Meta': {'object_name': 'UserProfile'},
+            'hipchat_alias': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '50', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'mobile_number': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '20', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'profile'", 'unique': 'True', 'to': u"orm['auth.User']"})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        }
+    }
+
+    complete_apps = ['cabotapp']

--- a/cabot/cabotapp/models.py
+++ b/cabot/cabotapp/models.py
@@ -357,6 +357,12 @@ class StatusCheck(PolymorphicModel):
         max_length=50, choices=Service.STATUSES, default=Service.CALCULATED_PASSING_STATUS, blank=True)
     last_run = models.DateTimeField(null=True)
     cached_health = models.TextField(editable=False, null=True)
+    runbook = models.TextField(
+        default=None,
+        null=True,
+        blank=True,
+        help_text='Notes for on-calls to correctly diagnose and resolve the alert. Supports HTML!',
+    )
 
     class Meta(PolymorphicModel.Meta):
         ordering = ['name']

--- a/cabot/cabotapp/views.py
+++ b/cabot/cabotapp/views.py
@@ -110,6 +110,7 @@ class SymmetricalForm(forms.ModelForm):
             self.save_m2m()
         return instance
 
+
 base_widgets = {
     'name': forms.TextInput(attrs={
         'style': 'width:30%',
@@ -155,6 +156,7 @@ class HttpStatusCheckForm(StatusCheckForm):
             'importance',
             'active',
             'retries',
+            'runbook',
         )
         widgets = dict(**base_widgets)
         widgets.update({
@@ -187,6 +189,7 @@ class JenkinsStatusCheckForm(StatusCheckForm):
             'importance',
             'retries',
             'max_queued_build_time',
+            'runbook',
         )
         widgets = dict(**base_widgets)
 
@@ -203,6 +206,7 @@ class TCPStatusCheckForm(StatusCheckForm):
             'importance',
             'active',
             'retries',
+            'runbook',
         )
         widgets = dict(**base_widgets)
         widgets.update({

--- a/cabot/metricsapp/forms/elastic.py
+++ b/cabot/metricsapp/forms/elastic.py
@@ -39,6 +39,7 @@ class ElasticsearchStatusCheckForm(StatusCheckForm):
             'frequency',
             'active',
             'retries',
+            'runbook',
         )
 
     def __init__(self, *args, **kwargs):

--- a/cabot/metricsapp/forms/grafana_elastic.py
+++ b/cabot/metricsapp/forms/grafana_elastic.py
@@ -19,6 +19,7 @@ class GrafanaElasticsearchStatusCheckForm(GrafanaStatusCheckForm):
             'time_range',
             'retries',
             'frequency',
+            'runbook',
         ]
         widgets = {
             'auto_sync': forms.CheckboxInput()
@@ -50,6 +51,7 @@ class GrafanaElasticsearchStatusCheckUpdateForm(GrafanaStatusCheckUpdateForm):
             'time_range',
             'retries',
             'frequency',
+            'runbook',
         ]
         widgets = {
             'auto_sync': forms.CheckboxInput()

--- a/cabot/templates/cabotapp/statuscheck_detail.html
+++ b/cabot/templates/cabotapp/statuscheck_detail.html
@@ -26,6 +26,12 @@
 <hr>
 <div class="row">
   <div class="col-xs-12">
+    <div class="col-xs-11"><h3>Runbook</h3></div>
+    <div class="col-xs-12">{% autoescape off %}{{ check.runbook }}{% endautoescape %}</div>
+  </div>
+<hr>
+<div class="row">
+  <div class="col-xs-12">
     <div class="col-xs-1"><h3><i class="fa fa-list"></i></h3></div>
     <div class="col-xs-11"><h3>Check results</h3></div>
   </div>


### PR DESCRIPTION
Summary: Add runbook field so that cabot checks have a run book.  This seems to work, but there may be some fit and finish to make it look nicer. Mainly it would be good to expand the size of the input box.

Test Plan: Tested locally. UT's pass, save for MYSQL, which also fails on master.

Reviewers: elainearbaugh

Subscribers: #consumer

JIRA Issues: INFRA-4358

Differential Revision: https://phabricator.team.affirm.com/D6640