### PR TITLE
Add support for activity counter per check

### DIFF
--- a/cabot/cabotapp/migrations/0033_auto__add_activitycounter__add_field_statuscheck_use_activity_counter.py
+++ b/cabot/cabotapp/migrations/0033_auto__add_activitycounter__add_field_statuscheck_use_activity_counter.py
@@ -1,0 +1,210 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding model 'ActivityCounter'
+        db.create_table(u'cabotapp_activitycounter', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('status_check', self.gf('django.db.models.fields.related.OneToOneField')(related_name='activity_counter', unique=True, to=orm['cabotapp.StatusCheck'])),
+            ('count', self.gf('django.db.models.fields.PositiveIntegerField')(default=0)),
+        ))
+        db.send_create_signal(u'cabotapp', ['ActivityCounter'])
+
+        # Adding field 'StatusCheck.use_activity_counter'
+        db.add_column(u'cabotapp_statuscheck', 'use_activity_counter',
+                      self.gf('django.db.models.fields.BooleanField')(default=False),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting model 'ActivityCounter'
+        db.delete_table(u'cabotapp_activitycounter')
+
+        # Deleting field 'StatusCheck.use_activity_counter'
+        db.delete_column(u'cabotapp_statuscheck', 'use_activity_counter')
+
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'cabotapp.activitycounter': {
+            'Meta': {'object_name': 'ActivityCounter'},
+            'count': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'status_check': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'activity_counter'", 'unique': 'True', 'to': u"orm['cabotapp.StatusCheck']"})
+        },
+        u'cabotapp.alertplugin': {
+            'Meta': {'object_name': 'AlertPlugin'},
+            'enabled': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'polymorphic_ctype': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'polymorphic_cabotapp.alertplugin_set'", 'null': 'True', 'to': u"orm['contenttypes.ContentType']"}),
+            'title': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'cabotapp.alertpluginuserdata': {
+            'Meta': {'unique_together': "(('title', 'user'),)", 'object_name': 'AlertPluginUserData'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'polymorphic_ctype': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'polymorphic_cabotapp.alertpluginuserdata_set'", 'null': 'True', 'to': u"orm['contenttypes.ContentType']"}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '30'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['cabotapp.UserProfile']"})
+        },
+        u'cabotapp.hipchatinstance': {
+            'Meta': {'object_name': 'HipchatInstance'},
+            'api_v2_key': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '20'}),
+            'server_url': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'cabotapp.httpstatuscheck': {
+            'Meta': {'ordering': "['name']", 'object_name': 'HttpStatusCheck', '_ormbases': [u'cabotapp.StatusCheck']},
+            'allow_http_redirects': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'endpoint': ('django.db.models.fields.TextField', [], {'null': 'True'}),
+            'header_match': ('django.db.models.fields.TextField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'http_body': ('django.db.models.fields.TextField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'http_method': ('django.db.models.fields.CharField', [], {'default': "'GET'", 'max_length': '10'}),
+            'http_params': ('django.db.models.fields.TextField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'password': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'status_code': ('django.db.models.fields.TextField', [], {'default': '200', 'null': 'True'}),
+            u'statuscheck_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['cabotapp.StatusCheck']", 'unique': 'True', 'primary_key': 'True'}),
+            'text_match': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'timeout': ('cabot.cabotapp.fields.PositiveIntegerMaxField', [], {'default': '30', 'null': 'True'}),
+            'username': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'verify_ssl_certificate': ('django.db.models.fields.BooleanField', [], {'default': 'True'})
+        },
+        u'cabotapp.jenkinsstatuscheck': {
+            'Meta': {'ordering': "['name']", 'object_name': 'JenkinsStatusCheck', '_ormbases': [u'cabotapp.StatusCheck']},
+            'max_queued_build_time': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            u'statuscheck_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['cabotapp.StatusCheck']", 'unique': 'True', 'primary_key': 'True'})
+        },
+        u'cabotapp.schedule': {
+            'Meta': {'object_name': 'Schedule'},
+            'fallback_officer': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']", 'null': 'True', 'blank': 'True'}),
+            'ical_url': ('django.db.models.fields.TextField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '50'})
+        },
+        u'cabotapp.service': {
+            'Meta': {'ordering': "['name']", 'object_name': 'Service'},
+            'alerts': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['cabotapp.AlertPlugin']", 'symmetrical': 'False', 'blank': 'True'}),
+            'alerts_enabled': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'email_alert': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'hackpad_id': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'hipchat_alert': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'hipchat_instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['cabotapp.HipchatInstance']", 'null': 'True', 'blank': 'True'}),
+            'hipchat_room_id': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_alert_sent': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.TextField', [], {}),
+            'old_overall_status': ('django.db.models.fields.TextField', [], {'default': "'PASSING'"}),
+            'overall_status': ('django.db.models.fields.TextField', [], {'default': "'PASSING'"}),
+            'schedules': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['cabotapp.Schedule']", 'null': 'True', 'blank': 'True'}),
+            'sms_alert': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'status_checks': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['cabotapp.StatusCheck']", 'symmetrical': 'False', 'blank': 'True'}),
+            'telephone_alert': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'url': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'users_to_notify': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.User']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'cabotapp.servicestatussnapshot': {
+            'Meta': {'object_name': 'ServiceStatusSnapshot'},
+            'did_send_alert': ('django.db.models.fields.IntegerField', [], {'default': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'num_checks_active': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'num_checks_failing': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'num_checks_passing': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'overall_status': ('django.db.models.fields.TextField', [], {'default': "'PASSING'"}),
+            'service': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'snapshots'", 'to': u"orm['cabotapp.Service']"}),
+            'time': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True'})
+        },
+        u'cabotapp.shift': {
+            'Meta': {'object_name': 'Shift'},
+            'deleted': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'end': ('django.db.models.fields.DateTimeField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'schedule': ('django.db.models.fields.related.ForeignKey', [], {'default': '1', 'to': u"orm['cabotapp.Schedule']"}),
+            'start': ('django.db.models.fields.DateTimeField', [], {}),
+            'uid': ('django.db.models.fields.TextField', [], {}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']"})
+        },
+        u'cabotapp.statuscheck': {
+            'Meta': {'ordering': "['name']", 'object_name': 'StatusCheck'},
+            'active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'cached_health': ('django.db.models.fields.TextField', [], {'null': 'True'}),
+            'calculated_status': ('django.db.models.fields.CharField', [], {'default': "'passing'", 'max_length': '50', 'blank': 'True'}),
+            'created_by': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']", 'null': 'True'}),
+            'frequency': ('django.db.models.fields.PositiveIntegerField', [], {'default': '5'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'importance': ('django.db.models.fields.CharField', [], {'default': "'ERROR'", 'max_length': '30'}),
+            'last_run': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            'name': ('django.db.models.fields.TextField', [], {}),
+            'polymorphic_ctype': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'polymorphic_cabotapp.statuscheck_set'", 'null': 'True', 'to': u"orm['contenttypes.ContentType']"}),
+            'retries': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0', 'null': 'True'}),
+            'runbook': ('django.db.models.fields.TextField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'use_activity_counter': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        u'cabotapp.statuscheckresult': {
+            'Meta': {'object_name': 'StatusCheckResult'},
+            'check': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['cabotapp.StatusCheck']"}),
+            'error': ('django.db.models.fields.TextField', [], {'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'job_number': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True'}),
+            'raw_data': ('django.db.models.fields.TextField', [], {'null': 'True'}),
+            'succeeded': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'time': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True'}),
+            'time_complete': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'db_index': 'True'})
+        },
+        u'cabotapp.tcpstatuscheck': {
+            'Meta': {'ordering': "['name']", 'object_name': 'TCPStatusCheck', '_ormbases': [u'cabotapp.StatusCheck']},
+            'address': ('django.db.models.fields.CharField', [], {'max_length': '1024'}),
+            'port': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            u'statuscheck_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['cabotapp.StatusCheck']", 'unique': 'True', 'primary_key': 'True'}),
+            'timeout': ('cabot.cabotapp.fields.PositiveIntegerMaxField', [], {'default': '8'})
+        },
+        u'cabotapp.userprofile': {
+            'Meta': {'object_name': 'UserProfile'},
+            'hipchat_alias': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '50', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'mobile_number': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '20', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'profile'", 'unique': 'True', 'to': u"orm['auth.User']"})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        }
+    }
+
+    complete_apps = ['cabotapp']

--- a/cabot/cabotapp/models.py
+++ b/cabot/cabotapp/models.py
@@ -27,6 +27,18 @@ from celery.utils.log import get_task_logger
 logger = get_task_logger(__name__)
 
 
+def clone_model(model):
+    '''
+    Utility function to clone a model. You must set both `id` and `pk` to
+    `None`, and then save it. It will store a new copy of the model in the
+    database, with a new primary key.
+    https://docs.djangoproject.com/en/2.0/topics/db/queries/#copying-model-instances
+    '''
+    model.id = None
+    model.pk = None
+    model.save()
+
+
 def serialize_recent_results(recent_results):
     if not recent_results:
         return ''

--- a/cabot/cabotapp/models.py
+++ b/cabot/cabotapp/models.py
@@ -1,7 +1,6 @@
 from celery.exceptions import SoftTimeLimitExceeded
 from django.conf import settings
 from django.contrib.auth.models import User
-from django.core.exceptions import ObjectDoesNotExist
 from django.db import models, transaction
 from polymorphic import PolymorphicModel
 
@@ -487,19 +486,6 @@ class StatusCheck(PolymorphicModel):
     def get_status_link(self):
         """Return a link with more information about the check"""
         return None
-
-    def ensure_activity_counter_exists(self, save=True):
-        '''
-        Create an ActivityCounter for this ServiceCheck.
-        - If 'save' is true, also save the ActivityCounter to the database.
-        - Returns the ActivityCounter object.
-        '''
-        try:
-            self.activity_counter
-        except ObjectDoesNotExist:
-            self.activity_counter = ActivityCounter.objects.create(status_check_id=self.id)
-            self.activity_counter.save()
-        return self.activity_counter
 
 
 class ActivityCounter(models.Model):

--- a/cabot/cabotapp/tasks.py
+++ b/cabot/cabotapp/tasks.py
@@ -63,9 +63,7 @@ def run_status_check(pk):
 def run_all_checks():
     checks = models.StatusCheck.objects.filter(active=True).all()
     for check in checks:
-        if check.last_run:
-            next_schedule = check.last_run + timedelta(minutes=check.frequency)
-        if (not check.last_run) or timezone.now() > next_schedule:
+        if check.should_run():
             check_queue = _classify_status_check(check.pk)
             run_status_check.apply_async((check.pk,), queue=check_queue)
 

--- a/cabot/cabotapp/tests/test_api.py
+++ b/cabot/cabotapp/tests/test_api.py
@@ -3,6 +3,7 @@ from rest_framework.reverse import reverse as api_reverse
 import base64
 import json
 from cabot.cabotapp.models import (
+    ActivityCounter,
     StatusCheck,
     JenkinsStatusCheck,
     Service,
@@ -284,7 +285,7 @@ class TestActivityCounterAPI(LocalTestCase):
     def setUp(self):
         super(TestActivityCounterAPI, self).setUp()
         # Use the HTTP check for testing
-        self.http_check.ensure_activity_counter_exists(save=False)
+        ActivityCounter.objects.create(status_check=self.http_check)
         self.http_check.use_activity_counter = True
         self.http_check.activity_counter.count = 1
         self.http_check.activity_counter.save()
@@ -310,6 +311,7 @@ class TestActivityCounterAPI(LocalTestCase):
     def test_counter_get_error_on_duplicate_names(self):
         # If two checks have the same name, check that we error out.
         # This should not be an issue once we enforce uniqueness on the name.
+        # TODO(evan): remove after making name unique
         clone_model(self.http_check)
         self.assertEqual(len(StatusCheck.objects.filter(name='Http Check')), 2)
         url = '/api/status-checks/activity-counter?name=Http Check'

--- a/cabot/cabotapp/tests/test_status_check.py
+++ b/cabot/cabotapp/tests/test_status_check.py
@@ -4,7 +4,7 @@ from datetime import timedelta
 from django.utils import timezone
 from cabot.cabotapp import tasks
 from mock import patch
-from cabot.cabotapp.models import HttpStatusCheck, Service
+from cabot.cabotapp.models import HttpStatusCheck, Service, clone_model
 from .utils import (
     LocalTestCase,
     fake_jenkins_success,
@@ -207,3 +207,9 @@ class TestStatusCheck(LocalTestCase):
         self.http_check.last_run = timezone.now() - timedelta(minutes=freq_mins-1)
         self.http_check.save()
         self.assertFalse(self.http_check.should_run())
+
+    def test_status_check_name_unique(self):
+        # TODO(evan): remove after making name unique
+        clone_model(self.http_check)
+        models = HttpStatusCheck.objects.filter(name=self.http_check.name)
+        self.assertEqual(len(models), 2)

--- a/cabot/cabotapp/views.py
+++ b/cabot/cabotapp/views.py
@@ -156,6 +156,7 @@ class HttpStatusCheckForm(StatusCheckForm):
             'importance',
             'active',
             'retries',
+            'use_activity_counter',
             'runbook',
         )
         widgets = dict(**base_widgets)
@@ -189,6 +190,7 @@ class JenkinsStatusCheckForm(StatusCheckForm):
             'importance',
             'retries',
             'max_queued_build_time',
+            'use_activity_counter',
             'runbook',
         )
         widgets = dict(**base_widgets)
@@ -206,6 +208,7 @@ class TCPStatusCheckForm(StatusCheckForm):
             'importance',
             'active',
             'retries',
+            'use_activity_counter',
             'runbook',
         )
         widgets = dict(**base_widgets)
@@ -708,6 +711,22 @@ def jsonify(d):
     return HttpResponse(json.dumps(d), content_type='application/json')
 
 
+def json_response(data, code, pretty=False):
+    '''
+    Return a JSON response containing some data. Supports pretty-printing.
+    '''
+    dump_opts = {}
+    if pretty:
+        dump_opts = {'sort_keys': True, 'indent': 4, 'separators': (',', ': ')}
+    content = json.dumps(data, **dump_opts)
+    return HttpResponse(content, status=code, content_type="application/json")
+
+
+def json_error_response(message, code):
+    '''Return a JSON response with an error message'''
+    return json_response({'detail': message}, code)
+
+
 class AuthComplete(View):
     def get(self, request, *args, **kwargs):
         backend = kwargs.pop('backend')
@@ -726,3 +745,90 @@ class LoginError(View):
 @register.filter
 def get_item(dictionary, key):
     return dictionary.get(key)
+
+
+class ViewError(Exception):
+    '''
+    A general-purpose HTTP request-processing exception that carries both an
+    error message and HTTP status code to be returned to the client.
+    '''
+    def __init__(self, message, code):
+        super(ViewError, self).__init__(message)
+        self.code = code
+
+
+class ActivityCounterView(View):
+
+    def get(self, request, pk):
+        '''Handle an HTTP GET request'''
+        try:
+            id = request.GET.get('id', None)
+            name = request.GET.get('name', None)
+
+            # We require the name or id of a check
+            if not (id or name):
+                return json_error_response('Please provide a name or id', 400)
+
+            # Lookup the check and make sure it has a related ActivityCounter
+            check = self._lookup_check(id, name)
+            check.ensure_activity_counter_exists()
+
+            # Perform the action and return the result
+            action = request.GET.get('action', 'read')
+            pretty = request.GET.get('pretty') == 'true'
+            message = self._handle_action(check, action)
+            data = {
+                'check.id': check.id,
+                'check.name': check.name,
+                'counter.count': check.activity_counter.count,
+                'counter.enabled': check.use_activity_counter,
+            }
+            if message:
+                data['detail'] = message
+            return json_response(data, 200, pretty=pretty)
+
+        except ViewError as e:
+            return json_error_response(e.message, e.code)
+
+    def _lookup_check(self, id, name):
+        '''
+        Lookup the check by id or name. Id is preferred.
+        - Returns a StatusCheck object.
+        - Will raise a ViewError if no check is found.
+        '''
+        check = None
+        if id:
+            check = StatusCheck.objects.filter(id=id).first()
+        if name and not check:
+            check = StatusCheck.objects.filter(name=name).first()
+        if check:
+            return check
+        raise ViewError('Check not found', 404)
+
+    def _handle_action(self, check, action):
+        '''
+        Perform the given action on the check.
+        - Return a message to be sent back in the response, or None.
+        - Raises a ViewError if given an invalid action.
+        '''
+        if action == 'read':
+            return None
+
+        if action == 'incr':
+            check.activity_counter.count += 1
+            check.activity_counter.save()
+            return 'counter incremented to {}'.format(check.activity_counter.count)
+
+        if action == 'decr':
+            if check.activity_counter.count > 0:
+                check.activity_counter.count -= 1
+                check.activity_counter.save()
+            return 'counter decremented to {}'.format(check.activity_counter.count)
+
+        if action == 'reset':
+            if check.activity_counter.count > 0:
+                check.activity_counter.count = 0
+                check.save()
+            return 'counter reset to 0'
+
+        raise ViewError("invalid action '{}'".format(action), 400)

--- a/cabot/metricsapp/forms/elastic.py
+++ b/cabot/metricsapp/forms/elastic.py
@@ -41,6 +41,7 @@ class ElasticsearchStatusCheckForm(StatusCheckForm):
             'active',
             'retries',
             'ignore_final_data_point',
+            'use_activity_counter',
             'runbook',
         )
 

--- a/cabot/metricsapp/forms/grafana_elastic.py
+++ b/cabot/metricsapp/forms/grafana_elastic.py
@@ -21,6 +21,7 @@ class GrafanaElasticsearchStatusCheckForm(GrafanaStatusCheckForm):
             'retries',
             'frequency',
             'ignore_final_data_point',
+            'use_activity_counter',
             'runbook',
         ]
         widgets = {
@@ -55,6 +56,7 @@ class GrafanaElasticsearchStatusCheckUpdateForm(GrafanaStatusCheckUpdateForm):
             'retries',
             'frequency',
             'ignore_final_data_point',
+            'use_activity_counter',
             'runbook',
         ]
         widgets = {

--- a/cabot/rest_urls.py
+++ b/cabot/rest_urls.py
@@ -8,20 +8,30 @@ logger = logging.getLogger(__name__)
 router = routers.DefaultRouter()
 
 
-def create_viewset(arg_model, arg_fields,
+def create_viewset(arg_model,
+                   arg_fields,
                    arg_read_only_fields=(),
                    no_create=False):
+    '''
+    Construct and return a ViewSet object:
+    - http://www.django-rest-framework.org/api-guide/viewsets/
+    '''
+
+    # Construct the list of model fields using (id, fields, read-only fields)
     arg_read_only_fields = ('id',) + arg_read_only_fields
     for field in arg_read_only_fields:
         if field not in arg_fields:
             arg_fields = arg_fields + (field,)
 
+    # Create a ModelSerializer class using the given model and fields.
+    # http://www.django-rest-framework.org/api-guide/serializers/#modelserializer
     class Serializer(serializers.ModelSerializer):
         class Meta:
             model = arg_model
             fields = arg_fields
             read_only_fields = arg_read_only_fields
 
+    # Create a ViewSet class that either does or does not allow for creation
     viewset_class = None
     if no_create:
         class NoCreateViewSet(mixins.RetrieveModelMixin,
@@ -34,12 +44,14 @@ def create_viewset(arg_model, arg_fields,
     else:
         viewset_class = viewsets.ModelViewSet
 
+    # Construct the queryset (ie. the list of model objects)
     arg_queryset = None
     if issubclass(arg_model, PolymorphicModel):
         arg_queryset = arg_model.objects.instance_of(arg_model)
     else:
         arg_queryset = arg_model.objects.all()
 
+    # Construct and return the ViewSet class
     class ViewSet(viewset_class):
         queryset = arg_queryset
         serializer_class = Serializer
@@ -71,13 +83,13 @@ status_check_fields = (
     'retries',
 )
 
-router.register(r'status_checks', create_viewset(
+router.register(r'status-checks', create_viewset(
     arg_model=models.StatusCheck,
     arg_fields=status_check_fields,
     no_create=True,
 ))
 
-router.register(r'http_checks', create_viewset(
+router.register(r'http-checks', create_viewset(
     arg_model=models.HttpStatusCheck,
     arg_fields=status_check_fields + (
         'endpoint',
@@ -90,14 +102,14 @@ router.register(r'http_checks', create_viewset(
     ),
 ))
 
-router.register(r'jenkins_checks', create_viewset(
+router.register(r'jenkins-checks', create_viewset(
     arg_model=models.JenkinsStatusCheck,
     arg_fields=status_check_fields + (
         'max_queued_build_time',
     ),
 ))
 
-router.register(r'tcp_checks', create_viewset(
+router.register(r'tcp-checks', create_viewset(
     arg_model=models.TCPStatusCheck,
     arg_fields=status_check_fields + (
         'address',
@@ -123,7 +135,7 @@ router.register(r'users', create_viewset(
     ),
 ))
 
-router.register(r'user_profiles', create_viewset(
+router.register(r'user-profiles', create_viewset(
     arg_model=models.UserProfile,
     arg_fields=(
         'user',
@@ -144,7 +156,7 @@ router.register(r'shifts', create_viewset(
     )
 ))
 
-router.register(r'alertplugins', create_viewset(
+router.register(r'alert-plugins', create_viewset(
     arg_model=alert.AlertPlugin,
     arg_fields=(
             'title',

--- a/cabot/urls.py
+++ b/cabot/urls.py
@@ -36,6 +36,7 @@ from cabot.cabotapp.views import (
     UserProfileUpdateView,
     ShiftListView,
     subscriptions,
+    ActivityCounterView,
 )
 
 from cabot.metricsapp.views import (
@@ -210,6 +211,10 @@ urlpatterns = patterns(
     url(r'^grafana/series/(?P<pk>\d+)/',
         view=GrafanaSeriesSelectView.as_view(),
         name='grafana-series-select'),
+
+    url(r'^api/status-checks/activity-counter(/?)',
+        view=ActivityCounterView.as_view(),
+        name='activity-counter'),
 
     # Comment below line to disable browsable rest api
     url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework')),

--- a/conf/development.env.example
+++ b/conf/development.env.example
@@ -5,7 +5,7 @@ DEBUG=t
 DATABASE_URL=postgres://postgres@db_psql:5432/postgres
 DJANGO_SETTINGS_MODULE=cabot.settings
 HIPCHAT_URL=https://api.hipchat.com/v1/rooms/message
-LOG_FILE=/dev/null
+LOG_FILE=/var/log/cabot.log
 PORT=5001
 
 # You shouldn't need to change anything above this line

--- a/tox.ini
+++ b/tox.ini
@@ -58,6 +58,27 @@ commands =
     bash -euc "docker-compose run --rm web python manage.py test cabot || (docker-compose down && exit 1)"
     bash -euc "docker-compose down"
 
+# For running PostgreSQL-based tests multiple times:
+# 1) Run `tox -e test-psql-setup` once.
+# 2) Run `tox -e test-psql-run` multiple times.
+# 3) Run `tox -e destroy-app` when done.
+[testenv:test-psql-setup]
+envdir = {toxworkdir}/test-psql
+commands =
+    # xml test results files go here
+    rm -rf build/test-psql
+    mkdir -p build/test-psql
+    cp conf/development.env.example conf/development.env
+    bash -euc "docker-compose build"
+    bash -euc "docker-compose up -d"
+    bash -euc "docker-compose run wait_psql"
+    bash -euc "docker-compose run wait_rabbitmq"
+
+[testenv:test-psql-run]
+envdir = {toxworkdir}/test-psql
+commands =
+    bash -euc "docker-compose run --rm web python manage.py test cabot"
+
 [testenv:test-mysql]
 commands =
     # xml test results files go here


### PR DESCRIPTION
This adds an 'activity counter' per check.  If enabled, the check will only run when the counter is > 0.

This change also adds an API endpoint:

```
/api/status-checks/activity-counter?id=<id>&name=<name>&action=<incr|decr|reset>
```

which allows a user / program to query, increment, decrement, or reset the counter for a given check.
