### PR TITLE
debian stretch npm fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7
+FROM python:2.7-jessie
 
 ENV PYTHONUNBUFFERED 1
 


### PR DESCRIPTION
Debian stretch removed npm from its repos so installation changed, force use of Jessie for testing