### PR TITLE
Enforce unique name for checks using activity counters

### DIFF
--- a/cabot/cabotapp/tests/test_api.py
+++ b/cabot/cabotapp/tests/test_api.py
@@ -311,7 +311,6 @@ class TestActivityCounterAPI(LocalTestCase):
     def test_counter_get_error_on_duplicate_names(self):
         # If two checks have the same name, check that we error out.
         # This should not be an issue once we enforce uniqueness on the name.
-        # TODO(evan): remove after making name unique
         clone_model(self.http_check)
         self.assertEqual(len(StatusCheck.objects.filter(name='Http Check')), 2)
         url = '/api/status-checks/activity-counter?name=Http Check'

--- a/cabot/cabotapp/views.py
+++ b/cabot/cabotapp/views.py
@@ -810,7 +810,6 @@ class ActivityCounterView(View):
             checks = StatusCheck.objects.filter(id=id)
         if name and not checks:
             checks = StatusCheck.objects.filter(name=name)
-            # TODO(evan): remove after making name unique
             if checks and len(checks) > 1:
                 raise ViewError("Multiple checks found with name '{}'".format(name), 500)
         if not checks:

--- a/cabot/static/arachnys/css/base.less
+++ b/cabot/static/arachnys/css/base.less
@@ -38,3 +38,7 @@ div.dataTables_info {
 div.dataTables_length {
   float: right;
 }
+
+.non-field-errors {
+  color: red;
+}

--- a/cabot/templates/cabotapp/_base_form.html
+++ b/cabot/templates/cabotapp/_base_form.html
@@ -1,6 +1,8 @@
 <div class="form-group">
   <div class="col-xs-10 col-xs-offset-2">
-    {{ form.non_field_errors }}
+    <div class="non-field-errors">
+      {{ form.non_field_errors }}
+    </div>
   </div>
 </div>
 {% csrf_token %}


### PR DESCRIPTION
Changes:

- Ensure that all checks using activity counters have unique names, so we can use the API to lookup such checks by name.
- Will display an error message in red when creating or updating a check and enabling activity counters.

Sample error message:

![image](https://user-images.githubusercontent.com/34492630/42716138-f25befca-86ae-11e8-8634-6e6cde6b64a3.png)

Tests pass, manual testing also succeeded.
