### PR TITLE
Fix run_all_checks when ActivityCounter model is missing

### DIFF
--- a/cabot/cabotapp/models.py
+++ b/cabot/cabotapp/models.py
@@ -405,10 +405,13 @@ class StatusCheck(PolymorphicModel):
 
     def should_run(self):
         '''Returns true if the check should run, false otherwise.'''
+
         # Do not run if the activity counter is enabled and zero
-        if self.use_activity_counter and self.activity_counter.count <= 0:
-            logger.info("Skipping check '{}', activity counter is zero".format(self.name))
-            return False
+        if self.use_activity_counter:
+            counter, _ = ActivityCounter.objects.get_or_create(status_check=self)
+            if counter.count <= 0:
+                logger.info("Skipping check '{}', activity counter is zero".format(self.name))
+                return False
 
         # Run if we haven't run at all
         if not self.last_run:

--- a/cabot/cabotapp/models.py
+++ b/cabot/cabotapp/models.py
@@ -406,10 +406,11 @@ class StatusCheck(PolymorphicModel):
     def should_run(self):
         '''Returns true if the check should run, false otherwise.'''
 
-        # Do not run if the activity counter is enabled and zero
+        # Do not run if the activity counter is enabled and zero.
+        # - If the DB entry does not exist, we assume a value of zero.
         if self.use_activity_counter:
-            counter, _ = ActivityCounter.objects.get_or_create(status_check=self)
-            if counter.count <= 0:
+            counters = ActivityCounter.objects.filter(status_check=self)
+            if len(counters) == 0 or counters[0].count <= 0:
                 logger.info("Skipping check '{}', activity counter is zero".format(self.name))
                 return False
 


### PR DESCRIPTION
`run_all_checks()` would fail if a StatusCheck had `use_activity_counter=True`, but did not have a corresponding entry in the ActivityCounter table. In this case it would raise a `DoesNotExist` exception.

The fix is simply to lookup the ActivityCounter via `ActivityCounter.objects.get_or_create()`

Tested locally by:

1. Creating a new check
2. Setting use_activity_counter=True
3. Confirming that the activity counter table was empty
4. Calling run_all_checks() via the django shell

Also added corresponding unit tests.