### PR TITLE
Allow consecutive_failures setting to apply to warnings, too

### DIFF
--- a/cabot/metricsapp/models/base.py
+++ b/cabot/metricsapp/models/base.py
@@ -77,9 +77,9 @@ class MetricsStatusCheckBase(StatusCheck):
     consecutive_failures = models.PositiveIntegerField(
         default=1,
         validators=[MinValueValidator(1)],
-        help_text='Number of consecutive data points that must exceed the high alert '
-                  'threshold before an alert is triggered. This setting is ignored '
-                  'for warnings.',
+        help_text='Number of consecutive data points that must exceed the alert '
+                  'threshold before an alert is triggered. Applies to both warning '
+                  'and high-alert thresholds.',
     )
 
     def _run(self):

--- a/cabot/metricsapp/tests/test_metrics_base.py
+++ b/cabot/metricsapp/tests/test_metrics_base.py
@@ -228,6 +228,15 @@ class TestMultipleThresholds(TestCase):
         self.assertEqual(result.error, u'CRITICAL prod.good.data: 9.2 not <= 9.0')
         self.assertEqual(self.metrics_check.importance, Service.CRITICAL_STATUS)
 
+        # It should also work for warnings
+        self.metrics_check.warning_value = 9.0
+        self.metrics_check.high_alert_value = 10.0
+        result = self.metrics_check._run()
+        self.assertEqual(result.check, self.metrics_check)
+        self.assertFalse(result.succeeded)
+        self.assertEqual(result.error, u'WARNING prod.good.data: 9.2 not <= 9.0')
+        self.assertEqual(self.metrics_check.importance, Service.WARNING_STATUS)
+
     @patch('cabot.metricsapp.models.MetricsStatusCheckBase.get_series', mock_get_series)
     @patch('time.time', mock_time)
     def test_consecutive_failures(self):
@@ -235,14 +244,25 @@ class TestMultipleThresholds(TestCase):
         Check that if the series contains enough consecutive failed points, a
         high alert is raised.
         """
+        self.metrics_check.consecutive_failures = 2
+
+        # Verify that it works for high alerts (error, critical)
         self.metrics_check.warning_value = 8.0
         self.metrics_check.high_alert_value = 9.0
-        self.metrics_check.consecutive_failures = 2
         result = self.metrics_check._run()
         self.assertEqual(result.check, self.metrics_check)
         self.assertFalse(result.succeeded)
         self.assertEqual(result.error, u'CRITICAL prod.good.data: 2 consecutive points not <= 9.0')
         self.assertEqual(self.metrics_check.importance, Service.CRITICAL_STATUS)
+
+        # It should also work for warnings
+        self.metrics_check.warning_value = 9.0
+        self.metrics_check.high_alert_value = 10.0
+        result = self.metrics_check._run()
+        self.assertEqual(result.check, self.metrics_check)
+        self.assertFalse(result.succeeded)
+        self.assertEqual(result.error, u'WARNING prod.good.data: 2 consecutive points not <= 9.0')
+        self.assertEqual(self.metrics_check.importance, Service.WARNING_STATUS)
 
     @patch('cabot.metricsapp.models.MetricsStatusCheckBase.get_series', mock_get_series)
     @patch('time.time', mock_time)
@@ -251,11 +271,20 @@ class TestMultipleThresholds(TestCase):
         Check that if the series contains failed points, but not enough are
         consecutive, that a high alert is NOT raised.
         """
+        self.metrics_check.consecutive_failures = 3
+
+        # Not enough points above the high-alert threshold, so we should get a warning
         self.metrics_check.warning_value = 8.0
         self.metrics_check.high_alert_value = 9.0
-        self.metrics_check.consecutive_failures = 3
         result = self.metrics_check._run()
         self.assertEqual(result.check, self.metrics_check)
         self.assertFalse(result.succeeded)
-        self.assertEqual(result.error, u'WARNING prod.good.data: 8.1 not <= 8.0')
+        self.assertEqual(result.error, u'WARNING prod.good.data: 3 consecutive points not <= 8.0')
         self.assertEqual(self.metrics_check.importance, Service.WARNING_STATUS)
+
+        # Not enough points above the warning threshold, so we shouldn't get an alert
+        self.metrics_check.warning_value = 9.0
+        self.metrics_check.high_alert_value = 10.0
+        result = self.metrics_check._run()
+        self.assertTrue(result.succeeded)
+        self.assertIsNone(result.error)


### PR DESCRIPTION
Currently, consecutive_failures only applies to high alerts. This change makes them apply to warnings as well.

I made some significant refactors to `metricsapp/api/base.py`. The diff may not be extremely helpful; you may want to read the new code directly.