### PR TITLE
Fix activity counter reset

### DIFF
--- a/cabot/cabotapp/tests/test_api.py
+++ b/cabot/cabotapp/tests/test_api.py
@@ -329,6 +329,7 @@ class TestActivityCounterAPI(LocalTestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(json.loads(response.content), expected_body)
+        self.assertEqual(StatusCheck.objects.filter(id=10102)[0].activity_counter.count, 2)
 
     def test_counter_decr(self):
         self._set_activity_counter(True, 1)
@@ -344,13 +345,14 @@ class TestActivityCounterAPI(LocalTestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(json.loads(response.content), expected_body)
+        self.assertEqual(StatusCheck.objects.filter(id=10102)[0].activity_counter.count, 0)
         # Decrementing when counter is zero has no effect
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(json.loads(response.content), expected_body)
 
     def test_counter_reset(self):
-        self._set_activity_counter(True, 1)
+        self._set_activity_counter(True, 11)
         url = '/api/status-checks/activity-counter?id=10102&action=reset'
         expected_body = {
             'check.id': 10102,
@@ -362,6 +364,7 @@ class TestActivityCounterAPI(LocalTestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(json.loads(response.content), expected_body)
+        self.assertEqual(StatusCheck.objects.filter(id=10102)[0].activity_counter.count, 0)
 
     def test_check_should_run_when_activity_counter_disabled(self):
         self._set_activity_counter(False, 0)

--- a/cabot/cabotapp/views.py
+++ b/cabot/cabotapp/views.py
@@ -839,7 +839,7 @@ class ActivityCounterView(View):
         if action == 'reset':
             if check.activity_counter.count > 0:
                 check.activity_counter.count = 0
-                check.save()
+                check.activity_counter.save()
             return 'counter reset to 0'
 
         raise ViewError("invalid action '{}'".format(action), 400)

--- a/cabot/cabotapp/views.py
+++ b/cabot/cabotapp/views.py
@@ -723,7 +723,7 @@ def json_response(data, code, pretty=False):
     dump_opts = {}
     if pretty:
         dump_opts = {'sort_keys': True, 'indent': 4, 'separators': (',', ': ')}
-    content = json.dumps(data, **dump_opts)
+    content = json.dumps(data, **dump_opts) + "\n"
     return HttpResponse(content, status=code, content_type="application/json")
 
 


### PR DESCRIPTION
In `ActivityCounterView#_handle_action()`, when resetting the activity counter, we were saving the `StatusCheck` and not its `ActivityCounter` object.  So while the API reported that the counter was reset to zero, it wasn't actually saved to the DB.

Fixed this, plus augmented the tests to check that the new counter values make it to the DB.

I also added a newline to the activity-counter API JSON response, just to make curl output a little nicer at the command line.