### PR TITLE
[INFRA-7354] Check schedule iCal URL in update_schedule_problems

### DIFF
--- a/cabot/cabotapp/models.py
+++ b/cabot/cabotapp/models.py
@@ -297,6 +297,7 @@ class Schedule(models.Model):
         :return: String containing the calendar data
         """
         resp = requests.get(self.ical_url)
+        resp.raise_for_status()
         return Calendar.from_ical(resp.content)
 
     def __unicode__(self):

--- a/cabot/cabotapp/tests/test_schedules.py
+++ b/cabot/cabotapp/tests/test_schedules.py
@@ -380,7 +380,7 @@ There are gaps in the schedule (times are UTC):
     def test_validate_schedule_ical_404(self):
         update_schedule_problems(self.schedule)
         self.assertTrue(self.schedule.has_problems())
-        self.assertEquals(self.schedule.problems.text, "The schedule's iCal URL returns an error "
+        self.assertEquals(self.schedule.problems.text, "The schedule's iCal URL returns an HTTP error "
                                                        "(404 Client Error: Not Found for url: http_response.html).")
 
     @patch('cabot.cabotapp.models.requests.get', fake_http_200_response)

--- a/cabot/cabotapp/tests/test_schedules.py
+++ b/cabot/cabotapp/tests/test_schedules.py
@@ -12,9 +12,10 @@ from cabot.cabotapp.models import (
     get_duty_officers,
     get_all_duty_officers,
     update_shifts, Schedule)
+from cabot.cabotapp.schedule_validation import update_schedule_problems
 from cabot.cabotapp.utils import build_absolute_url
 from cabot.metricsapp.defs import SCHEDULE_PROBLEMS_EMAIL_SNOOZE_HOURS
-from .utils import LocalTestCase, fake_calendar
+from .utils import LocalTestCase, fake_calendar, fake_http_404_response, fake_http_200_response
 
 
 def _create_fake_users(usernames):
@@ -170,6 +171,12 @@ class TestScheduleValidation(LocalTestCase):
             'shortname@affirm.com',
         ])
 
+        # need the patch here so the 'ical url works' check triggered in schedule.save() passes
+        with patch('cabot.cabotapp.models.requests.get', fake_calendar):
+            self.schedule.ical_url = 'calendar_response.ics'
+            self.schedule.fallback_officer = User.objects.get(email='dolores@affirm.com')
+            self.schedule.save()
+
         self.secondary_schedule.delete()
         self.secondary_schedule = None
 
@@ -296,6 +303,8 @@ There are gaps in the schedule (times are UTC):
     def test_validate_schedule_ui_shows_problems(self, fake_now):
         fake_now.return_value = datetime(2018, 8, 15, 0, 3, 54, 598552, tzinfo=timezone.utc)
 
+        self.assertFalse(self.schedule.has_problems())
+
         # check that the UI doesn't show any problems
         response = self.client.get(reverse('shifts'))
         self.assertNotContains(response, "Problems", status_code=200)
@@ -313,6 +322,8 @@ There are gaps in the schedule (times are UTC):
     @patch('cabot.cabotapp.models.timezone.now')
     def test_validate_schedule_ui_shows_problems_while_silenced(self, fake_now):
         fake_now.return_value = datetime(2018, 8, 15, 0, 3, 54, 598552, tzinfo=timezone.utc)
+
+        self.assertFalse(self.schedule.has_problems())
 
         # check that the UI doesn't show any problems
         response = self.client.get(reverse('shifts'))
@@ -357,3 +368,25 @@ There are gaps in the schedule (times are UTC):
 
         self.assertTrue(fake_send_mail.called)
         self.assertEqual(self.schedule.problems.text, problems)
+
+    @patch('cabot.cabotapp.models.requests.get', fake_calendar)
+    def test_validate_schedule_no_url(self):
+        self.schedule.ical_url = ''  # no calendar
+        self.schedule.save()
+        self.assertTrue(self.schedule.has_problems())
+        self.assertEquals(self.schedule.problems.text, "The schedule's iCal URL is empty.")
+
+    @patch('cabot.cabotapp.models.requests.get', fake_http_404_response)
+    def test_validate_schedule_ical_404(self):
+        update_schedule_problems(self.schedule)
+        self.assertTrue(self.schedule.has_problems())
+        self.assertEquals(self.schedule.problems.text, "The schedule's iCal URL returns an error "
+                                                       "(404 Client Error: Not Found for url: http_response.html).")
+
+    @patch('cabot.cabotapp.models.requests.get', fake_http_200_response)
+    def test_validate_schedule_bad_ical_data(self):
+        update_schedule_problems(self.schedule)
+        self.assertTrue(self.schedule.has_problems())
+        self.assertEquals(self.schedule.problems.text, "The schedule's iCal URL returns an invalid iCal file "
+                                                       "(Content line could not be parsed into parts: "
+                                                       "'<!DOCTYPE html>': <!DOCTYPE html>).")

--- a/cabot/cabotapp/tests/utils.py
+++ b/cabot/cabotapp/tests/utils.py
@@ -168,6 +168,11 @@ def fake_http_404_response(*args, **kwargs):
     resp = Mock()
     resp.content = get_content('http_response.html')
     resp.status_code = 404
+
+    # mock response.raise_for_status (matches requests 2.19.1 format)
+    err_msg = '404 Client Error: Not Found for url: http_response.html'
+    resp.raise_for_status = Mock(side_effect=requests.HTTPError(err_msg, response=resp))
+
     return resp
 
 


### PR DESCRIPTION
This check distinguishes between three possible problems with the iCal URL:
* The iCal URL is empty (treated as a problem)
* The iCal URL is broken (connection error, HTTP 4xx/5xx, ...)
  - `Schedule.get_calendar_data()` now checks for this using `requests.Response.raise_for_status()`
* The iCal URL isn't returning valid iCal data (failing to parse)
  - For example, if someone entered `http://google.com`or a link to another calendar format

There are also unit tests for each case.

---

Also, this commit splits up the "update shifts" and "update schedule problems" logic into two independent try/except blocks. Previously, if updating shifts failed, update problems would never run (!!).