### PR TITLE
Stop querying the DB for every service in the services list

### DIFF
--- a/cabot/cabotapp/views.py
+++ b/cabot/cabotapp/views.py
@@ -602,19 +602,21 @@ class ServiceListView(LoginRequiredMixin, ListView):
         # don't exist in django 1.6 :(
         return Service.objects.all().order_by('name')\
             .extra(select={
-            'active_checks_count':
-                "SELECT COUNT(*)\n"
-                "FROM cabotapp_statuscheck\n"
-                "INNER JOIN cabotapp_service_status_checks ON (cabotapp_statuscheck.id = cabotapp_service_status_checks.statuscheck_id)\n"
-                "WHERE cabotapp_statuscheck.active = TRUE\n"
-                "  AND cabotapp_service_status_checks.service_id = cabotapp_service.id",
-            'inactive_checks_count':
-                "SELECT COUNT(*)\n"
-                "FROM cabotapp_statuscheck\n"
-                "INNER JOIN cabotapp_service_status_checks ON (cabotapp_statuscheck.id = cabotapp_service_status_checks.statuscheck_id)\n"
-                "WHERE cabotapp_statuscheck.active = FALSE\n"
-                "  AND cabotapp_service_status_checks.service_id = cabotapp_service.id",
-        })
+                'active_checks_count':
+                    "SELECT COUNT(*)\n"
+                    "FROM cabotapp_statuscheck\n"
+                    "INNER JOIN cabotapp_service_status_checks "
+                    "ON (cabotapp_statuscheck.id = cabotapp_service_status_checks.statuscheck_id)\n"
+                    "WHERE cabotapp_statuscheck.active = TRUE\n"
+                    "  AND cabotapp_service_status_checks.service_id = cabotapp_service.id",
+                'inactive_checks_count':
+                    "SELECT COUNT(*)\n"
+                    "FROM cabotapp_statuscheck\n"
+                    "INNER JOIN cabotapp_service_status_checks "
+                    "ON (cabotapp_statuscheck.id = cabotapp_service_status_checks.statuscheck_id)\n"
+                    "WHERE cabotapp_statuscheck.active = FALSE\n"
+                    "  AND cabotapp_service_status_checks.service_id = cabotapp_service.id",
+            })
 
     def get_context_data(self, **kwargs):
         context = super(ServiceListView, self).get_context_data(**kwargs)

--- a/cabot/templates/cabotapp/_service_list.html
+++ b/cabot/templates/cabotapp/_service_list.html
@@ -26,10 +26,10 @@
             <span class="label label-{% if not service.alerts_enabled %}warning{% else %}{% if service.overall_status == service.PASSING_STATUS %}success{% else %}danger{% endif %}{% endif %}">{% if service.alerts_enabled %}{{ service.overall_status|lower|capfirst }}{% else %}Disabled{% endif %}</span>
           </td>
           <td>
-            <span class="label label-{% if service.active_status_checks.all.count > 0 %}{% if service.overall_status != service.PASSING_STATUS %}danger{% else %}success{% endif %}{% else %}default{% endif %}">{{ service.active_status_checks.all.count }}</span>
+            <span class="label label-{% if service.active_checks_count > 0 %}{% if service.overall_status != service.PASSING_STATUS %}danger{% else %}success{% endif %}{% else %}default{% endif %}">{{ service.active_checks_count }}</span>
           </td>
           <td>
-            <span class="label label-{% if service.inactive_status_checks.all.count > 0 %}warning{% else %}default{% endif %}">{{ service.inactive_status_checks.all.count }}</span>
+            <span class="label label-{% if service.inactive_checks_count > 0 %}warning{% else %}default{% endif %}">{{ service.inactive_checks_count }}</span>
           </td>
           <td class="text-right">
             <a class="btn btn-xs" href="{% url "update-service" pk=service.id %}" role="button">


### PR DESCRIPTION
Unfortunately, `service.active_status_checks.count` and `service.inactive_status_checks.count` seem to create a new queryset instead of using the prefetched data, which causes 4 DB queries per service while loading the services list page.

This PR moves number of active/inactive status checks into manual queries that are batched into the main queryset. This brings the number of queries down to 5 in total, instead of roughly 3 + 4*`n_services`.

Used django-silky to profile the DB queries.