### PR TITLE
Add options for handling empty data series

### DIFF
--- a/cabot/metricsapp/defs.py
+++ b/cabot/metricsapp/defs.py
@@ -28,3 +28,15 @@ GRAFANA_RENDERED_IMAGE_WIDTH = 2000
 METRIC_STATUS_TIME_RANGE_DEFAULT = 30
 
 SCHEDULE_PROBLEMS_EMAIL_SNOOZE_HOURS = [4, 12, 24]  # which "silence for" links are shown in schedule problems emails
+
+ON_EMPTY_SERIES_PASS = 'pass'
+ON_EMPTY_SERIES_WARN = 'warn'
+ON_EMPTY_SERIES_FAIL = 'fail'
+ON_EMPTY_SERIES_FILL_ZERO = 'fill_zero'
+
+ON_EMPTY_SERIES_OPTIONS = (
+    (ON_EMPTY_SERIES_PASS, 'Pass'),
+    (ON_EMPTY_SERIES_WARN, 'Warn'),
+    (ON_EMPTY_SERIES_FAIL, 'Fail (error/critical)'),
+    (ON_EMPTY_SERIES_FILL_ZERO, 'Fill zero'),
+)

--- a/cabot/metricsapp/forms/grafana_elastic.py
+++ b/cabot/metricsapp/forms/grafana_elastic.py
@@ -6,10 +6,31 @@ from .grafana import GrafanaStatusCheckForm, GrafanaStatusCheckUpdateForm
 from cabot.metricsapp.models import ElasticsearchStatusCheck
 
 _GROUPS = (
-    ('Basic', ('name', 'active', 'service_set')),
-    ('Thresholds', ('check_type', 'warning_value', 'high_alert_importance', 'high_alert_value')),
-    ('Query', ('queries', 'time_range', 'consecutive_failures', 'retries', 'frequency', 'ignore_final_data_point')),
-    ('Advanced', ('auto_sync', 'use_activity_counter', 'runbook')),
+    ('Basic', (
+        'name',
+        'active',
+        'service_set',
+    )),
+    ('Thresholds', (
+        'check_type',
+        'warning_value',
+        'high_alert_importance',
+        'high_alert_value',
+    )),
+    ('Query', (
+        'queries',
+        'time_range',
+        'consecutive_failures',
+        'retries',
+        'frequency',
+        'ignore_final_data_point',
+        'on_empty_series',
+    )),
+    ('Advanced', (
+        'auto_sync',
+        'use_activity_counter',
+        'runbook',
+    )),
 )
 
 

--- a/cabot/metricsapp/migrations/0010_auto__add_field_metricsstatuscheckbase_on_empty_series.py
+++ b/cabot/metricsapp/migrations/0010_auto__add_field_metricsstatuscheckbase_on_empty_series.py
@@ -1,0 +1,135 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'MetricsStatusCheckBase.on_empty_series'
+        db.add_column(u'metricsapp_metricsstatuscheckbase', 'on_empty_series',
+                      self.gf('django.db.models.fields.CharField')(default='fill_zero', max_length=16),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'MetricsStatusCheckBase.on_empty_series'
+        db.delete_column(u'metricsapp_metricsstatuscheckbase', 'on_empty_series')
+
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'cabotapp.statuscheck': {
+            'Meta': {'ordering': "['name']", 'object_name': 'StatusCheck'},
+            'active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'cached_health': ('django.db.models.fields.TextField', [], {'null': 'True'}),
+            'calculated_status': ('django.db.models.fields.CharField', [], {'default': "'passing'", 'max_length': '50', 'blank': 'True'}),
+            'created_by': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']", 'null': 'True'}),
+            'frequency': ('django.db.models.fields.PositiveIntegerField', [], {'default': '5'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'importance': ('django.db.models.fields.CharField', [], {'default': "'ERROR'", 'max_length': '30'}),
+            'last_run': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            'name': ('django.db.models.fields.TextField', [], {}),
+            'polymorphic_ctype': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'polymorphic_cabotapp.statuscheck_set'", 'null': 'True', 'to': u"orm['contenttypes.ContentType']"}),
+            'retries': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0', 'null': 'True'}),
+            'runbook': ('django.db.models.fields.TextField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'use_activity_counter': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'metricsapp.elasticsearchsource': {
+            'Meta': {'object_name': 'ElasticsearchSource', '_ormbases': ['metricsapp.MetricsSourceBase']},
+            'index': ('django.db.models.fields.TextField', [], {'default': "'*'", 'max_length': '50'}),
+            'max_concurrent_searches': ('django.db.models.fields.IntegerField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            u'metricssourcebase_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['metricsapp.MetricsSourceBase']", 'unique': 'True', 'primary_key': 'True'}),
+            'timeout': ('django.db.models.fields.IntegerField', [], {'default': '20'}),
+            'urls': ('django.db.models.fields.TextField', [], {'max_length': '250'})
+        },
+        'metricsapp.elasticsearchstatuscheck': {
+            'Meta': {'ordering': "['name']", 'object_name': 'ElasticsearchStatusCheck', '_ormbases': ['metricsapp.MetricsStatusCheckBase']},
+            'ignore_final_data_point': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            u'metricsstatuscheckbase_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['metricsapp.MetricsStatusCheckBase']", 'unique': 'True', 'primary_key': 'True'}),
+            'queries': ('django.db.models.fields.TextField', [], {'max_length': '10000'})
+        },
+        'metricsapp.grafanadatasource': {
+            'Meta': {'object_name': 'GrafanaDataSource'},
+            'grafana_instance': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['metricsapp.GrafanaInstance']"}),
+            'grafana_source_name': ('django.db.models.fields.CharField', [], {'max_length': '30'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'metrics_source_base': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['metricsapp.MetricsSourceBase']"})
+        },
+        'metricsapp.grafanainstance': {
+            'Meta': {'object_name': 'GrafanaInstance'},
+            'api_key': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'}),
+            'sources': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['metricsapp.MetricsSourceBase']", 'through': "orm['metricsapp.GrafanaDataSource']", 'symmetrical': 'False'}),
+            'url': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'metricsapp.grafanapanel': {
+            'Meta': {'object_name': 'GrafanaPanel'},
+            'dashboard_uri': ('django.db.models.fields.CharField', [], {'max_length': '40'}),
+            'grafana_instance': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['metricsapp.GrafanaInstance']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'panel_id': ('django.db.models.fields.IntegerField', [], {}),
+            'panel_url': ('django.db.models.fields.CharField', [], {'max_length': '1024', 'null': 'True'}),
+            'selected_series': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'series_ids': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'metricsapp.metricssourcebase': {
+            'Meta': {'object_name': 'MetricsSourceBase'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'metricsapp.metricsstatuscheckbase': {
+            'Meta': {'ordering': "['name']", 'object_name': 'MetricsStatusCheckBase', '_ormbases': [u'cabotapp.StatusCheck']},
+            'auto_sync': ('django.db.models.fields.NullBooleanField', [], {'default': 'True', 'null': 'True', 'blank': 'True'}),
+            'check_type': ('django.db.models.fields.CharField', [], {'max_length': '30'}),
+            'consecutive_failures': ('django.db.models.fields.PositiveIntegerField', [], {'default': '1'}),
+            'grafana_panel': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['metricsapp.GrafanaPanel']", 'null': 'True'}),
+            'high_alert_importance': ('django.db.models.fields.CharField', [], {'default': "'ERROR'", 'max_length': '30'}),
+            'high_alert_value': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'on_empty_series': ('django.db.models.fields.CharField', [], {'default': "'fill_zero'", 'max_length': '16'}),
+            'source': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['metricsapp.MetricsSourceBase']"}),
+            u'statuscheck_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['cabotapp.StatusCheck']", 'unique': 'True', 'primary_key': 'True'}),
+            'time_range': ('django.db.models.fields.IntegerField', [], {'default': '30'}),
+            'warning_value': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['metricsapp']

--- a/cabot/metricsapp/models/base.py
+++ b/cabot/metricsapp/models/base.py
@@ -5,7 +5,8 @@ from cabot.cabotapp.models import Service, StatusCheck
 from cabot.cabotapp.utils import build_absolute_url
 from cabot.metricsapp.api import run_metrics_check
 from cabot.cabotapp.defs import CHECK_TYPES
-from cabot.metricsapp.defs import METRIC_STATUS_TIME_RANGE_DEFAULT
+from cabot.metricsapp import defs
+import time
 
 
 class MetricsSourceBase(models.Model):
@@ -62,7 +63,7 @@ class MetricsStatusCheckBase(StatusCheck):
         help_text='If this expression evaluates to False, the check will fail with an error or critical level alert.'
     )
     time_range = models.IntegerField(
-        default=METRIC_STATUS_TIME_RANGE_DEFAULT,
+        default=defs.METRIC_STATUS_TIME_RANGE_DEFAULT,
         help_text='Time range in minutes the check gathers data for.',
     )
     grafana_panel = models.ForeignKey(
@@ -82,6 +83,13 @@ class MetricsStatusCheckBase(StatusCheck):
                   'threshold before an alert is triggered. Applies to both warning '
                   'and high-alert thresholds.',
     )
+    on_empty_series = models.CharField(
+        choices=defs.ON_EMPTY_SERIES_OPTIONS,
+        default=defs.ON_EMPTY_SERIES_FILL_ZERO,
+        max_length=16,
+        help_text='Action to take if the series is empty. Options are: pass, warn, or fail immediately, '
+                  'or insert a single data point with value zero (default, for backwards compatibility).'
+    )
 
     def _run(self):
         """Run a status check"""
@@ -89,25 +97,42 @@ class MetricsStatusCheckBase(StatusCheck):
 
     def get_series(self):
         """
-        Implemented by subclasses.
-        Parse raw data from a data source into the format
-        status:
-        error_message:
-        error_code:
-        raw:
-        # Parsed data
-        data:
-          - series: a.b.c.d
-            datapoints:
-              - [timestamp, value]
-              - [timestamp, value]
-          - series: a.b.c.p.q
-            datapoints:
-              - [timestamp, value]
+        Fetches time series data, optionally fills it (if configured to do so via the on_empty_series field),
+        and returns the series.
         :param check: the status check
-        :return the parsed data
+        :return the time series data
         """
+        series = self._get_parsed_data()
+        self._fill_parsed_data(series)
+        return series
+
+    def _get_parsed_data(self):
+        '''
+        To be implemented by subclasses. Parse the raw data from a data source into the format:
+
+            status:
+            error_message:
+            error_code:
+            raw:
+            # Parsed data
+            data:
+              - series: a.b.c.d
+                datapoints:
+                  - [timestamp, value]
+                  - [timestamp, value]
+              - series: a.b.c.p.q
+                datapoints:
+                  - [timestamp, value]
+
+        :return: the parsed data
+        '''
         raise NotImplementedError('MetricsStatusCheckBase has no data source.')
+
+    def _fill_parsed_data(self, series):
+        '''Given the parsed series data, if it is empty and should be filled, fill it.'''
+        if series['data'] == []:
+            if self.on_empty_series == defs.ON_EMPTY_SERIES_FILL_ZERO:
+                series['data'].append(dict(series='no_data_fill_0', datapoints=[[int(time.time()), 0]]))
 
     def get_url_for_check(self):
         """Get the url for viewing this check"""

--- a/cabot/metricsapp/models/base.py
+++ b/cabot/metricsapp/models/base.py
@@ -88,7 +88,7 @@ class MetricsStatusCheckBase(StatusCheck):
         default=defs.ON_EMPTY_SERIES_FILL_ZERO,
         max_length=16,
         help_text='Action to take if the series is empty. Options are: pass, warn, or fail immediately, '
-                  'or insert a single data point with value zero (default, for backwards compatibility).'
+                  'or insert a single data point with value zero.'
     )
 
     def _run(self):

--- a/cabot/metricsapp/models/elastic.py
+++ b/cabot/metricsapp/models/elastic.py
@@ -112,26 +112,7 @@ class ElasticsearchStatusCheck(MetricsStatusCheckBase):
         for query in queries:
             validate_query(query)
 
-    def get_series(self):
-        """
-        Get the relevant data for a check from Elasticsearch and parse it
-        into a generic format.
-        :param check: the ElasticsearchStatusCheck
-        :return data in the format
-            status:
-            error_message:
-            error_code:
-            raw:
-            data:
-              - series: a.b.c.d
-                datapoints:
-                  - [timestamp, value]
-                  - [timestamp, value]
-              - series: a.b.c.p.q
-                datapoints:
-                  - [timestamp, value]
-                check:
-        """
+    def _get_parsed_data(self):
         # Error will be set to true if we encounter an error
         parsed_data = dict(raw=[], error=False, data=[])
         source = ElasticsearchSource.objects.get(name=self.source.name)
@@ -166,11 +147,6 @@ class ElasticsearchStatusCheck(MetricsStatusCheckBase):
             parsed_data['error_code'] = type(e).__name__
             parsed_data['error_message'] = str(e)
             parsed_data['error'] = True
-
-        # If there's no data, fill in a 0 so the check doesn't fail.
-        # TODO: fill value could be set based on "Stacking & Null value" in Grafana
-        if parsed_data['data'] == []:
-            parsed_data['data'].append(dict(series='no_data_fill_0', datapoints=[[int(time.time()), 0]]))
 
         return parsed_data
 

--- a/cabot/metricsapp/tests/test_metrics_base.py
+++ b/cabot/metricsapp/tests/test_metrics_base.py
@@ -327,9 +327,9 @@ class TestEmptySeries(TestCase):
             name='test',
             created_by=self.user,
             source=self.source,
-            check_type='<',
-            warning_value=9.0,
-            high_alert_value=10,
+            check_type='>',
+            warning_value=10,
+            high_alert_value=5,
             high_alert_importance=Service.CRITICAL_STATUS,
         )
 
@@ -341,6 +341,10 @@ class TestEmptySeries(TestCase):
         # get_series() is filled
         expected = [{'datapoints': [[mock_time(), 0.0]], 'series': 'no_data_fill_0'}]
         self.assertEqual(self.check.get_series()['data'], expected)
+        # The test should fail
+        result = self.check._run()
+        self.assertFalse(result.succeeded)
+        self.assertEqual(result.error, u'CRITICAL no_data_fill_0: 0.0 not > 5.0')
         self.assertEqual(self.check.importance, Service.CRITICAL_STATUS)
 
     @patch('cabot.metricsapp.models.MetricsStatusCheckBase._get_parsed_data', mock_get_empty_series)
@@ -360,7 +364,7 @@ class TestEmptySeries(TestCase):
         self.check.on_empty_series = defs.ON_EMPTY_SERIES_WARN
         # Points should not be filled in
         self.assertEqual(self.check.get_series()['data'], [])
-        # The test should succeed
+        # The test should warn
         result = self.check._run()
         self.assertFalse(result.succeeded)
         self.assertEqual(result.error, u'WARNING: no data')
@@ -372,7 +376,7 @@ class TestEmptySeries(TestCase):
         self.check.on_empty_series = defs.ON_EMPTY_SERIES_FAIL
         # Points should not be filled in
         self.assertEqual(self.check.get_series()['data'], [])
-        # The test should succeed
+        # The test should fail
         result = self.check._run()
         self.assertFalse(result.succeeded)
         self.assertEqual(result.error, u'CRITICAL: no data')

--- a/cabot/metricsapp/tests/test_metrics_base.py
+++ b/cabot/metricsapp/tests/test_metrics_base.py
@@ -5,6 +5,7 @@ import os
 import yaml
 from cabot.cabotapp.models import Service
 from cabot.metricsapp.models import MetricsStatusCheckBase, MetricsSourceBase
+from cabot.metricsapp import defs
 
 
 def get_content(filename):
@@ -19,6 +20,10 @@ def mock_get_series(*args):
 
 def get_series_error(*args):
     return yaml.load(get_content('metrics_error.yaml'))
+
+
+def mock_get_empty_series(*args):
+    return {'error': False, 'raw': 'rawstuff', 'data': []}
 
 
 def mock_time():
@@ -312,3 +317,63 @@ class TestMultipleThresholds(TestCase):
         # If this fails, we might see:
         # "CRITICAL alert.high_alert_threshold: 2 consecutive points not < 10.0"
         self.assertEqual(result.error, u'WARNING prod.good.data: 2 consecutive points not < 9.0')
+
+
+class TestEmptySeries(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user('user')
+        self.source = MetricsSourceBase.objects.create(name='source')
+        self.check = MetricsStatusCheckBase(
+            name='test',
+            created_by=self.user,
+            source=self.source,
+            check_type='<',
+            warning_value=9.0,
+            high_alert_value=10,
+            high_alert_importance=Service.CRITICAL_STATUS,
+        )
+
+    @patch('cabot.metricsapp.models.MetricsStatusCheckBase._get_parsed_data', mock_get_empty_series)
+    @patch('time.time', mock_time)
+    def test_fill_single_zero_by_default(self):
+        # _get_parsed_data() does not get filled. We expect an empty array.
+        self.assertEqual(self.check._get_parsed_data()['data'], [])
+        # get_series() is filled
+        expected = [{'datapoints': [[mock_time(), 0.0]], 'series': 'no_data_fill_0'}]
+        self.assertEqual(self.check.get_series()['data'], expected)
+        self.assertEqual(self.check.importance, Service.CRITICAL_STATUS)
+
+    @patch('cabot.metricsapp.models.MetricsStatusCheckBase._get_parsed_data', mock_get_empty_series)
+    @patch('time.time', mock_time)
+    def test_immediate_success(self):
+        self.check.on_empty_series = defs.ON_EMPTY_SERIES_PASS
+        # Points should not be filled in
+        self.assertEqual(self.check.get_series()['data'], [])
+        # The test should succeed
+        result = self.check._run()
+        self.assertTrue(result.succeeded)
+        self.assertEqual(result.error, u'SUCCESS: no data')
+
+    @patch('cabot.metricsapp.models.MetricsStatusCheckBase._get_parsed_data', mock_get_empty_series)
+    @patch('time.time', mock_time)
+    def test_immediate_warning(self):
+        self.check.on_empty_series = defs.ON_EMPTY_SERIES_WARN
+        # Points should not be filled in
+        self.assertEqual(self.check.get_series()['data'], [])
+        # The test should succeed
+        result = self.check._run()
+        self.assertFalse(result.succeeded)
+        self.assertEqual(result.error, u'WARNING: no data')
+        self.assertEqual(self.check.importance, Service.WARNING_STATUS)
+
+    @patch('cabot.metricsapp.models.MetricsStatusCheckBase._get_parsed_data', mock_get_empty_series)
+    @patch('time.time', mock_time)
+    def test_immediate_failure(self):
+        self.check.on_empty_series = defs.ON_EMPTY_SERIES_FAIL
+        # Points should not be filled in
+        self.assertEqual(self.check.get_series()['data'], [])
+        # The test should succeed
+        result = self.check._run()
+        self.assertFalse(result.succeeded)
+        self.assertEqual(result.error, u'CRITICAL: no data')
+        self.assertEqual(self.check.importance, Service.CRITICAL_STATUS)

--- a/cabot/metricsapp/tests/test_metrics_base.py
+++ b/cabot/metricsapp/tests/test_metrics_base.py
@@ -376,7 +376,14 @@ class TestEmptySeries(TestCase):
         self.check.on_empty_series = defs.ON_EMPTY_SERIES_FAIL
         # Points should not be filled in
         self.assertEqual(self.check.get_series()['data'], [])
-        # The test should fail
+        # The test should fail and respect the high_alert_importance (ERROR here)
+        self.check.high_alert_importance = Service.ERROR_STATUS
+        result = self.check._run()
+        self.assertFalse(result.succeeded)
+        self.assertEqual(result.error, u'ERROR: no data')
+        self.assertEqual(self.check.importance, Service.ERROR_STATUS)
+        # This time it should fail with CRITICAL
+        self.check.high_alert_importance = Service.CRITICAL_STATUS
         result = self.check._run()
         self.assertFalse(result.succeeded)
         self.assertEqual(result.error, u'CRITICAL: no data')

--- a/cabot/metricsapp/tests/test_views.py
+++ b/cabot/metricsapp/tests/test_views.py
@@ -41,6 +41,7 @@ class TestMetricsReviewChanges(TestCase):
             'retries': 0,
             'frequency': 5,
             'ignore_final_data_point': True,
+            'on_empty_series': 'fill_zero',
             'use_activity_counter': False,
             'runbook': '',
         }


### PR DESCRIPTION
Current Cabot behavior is to add a single data point of zero to an empty series. This has a few problems:

- It's not very flexible.
- We'll often want to either succeed or fail immediately.
- If a check requires multiple failed data points before failing, the check will always succeed when only given a single point.

This change allows us to specify how a check should handle an empty data series:

1. Succeed immediately.
2. Warn immediately.
3. Fail immediately (error/critical)
4. Add a single data point with a configurable value (current default behavior)

The default behavior remains unchanged - fill a single value of zero - so that behavior for existing checks remains unchanged.
