### PR TITLE
Add run_delay option to checks (attempt 2)

### DIFF
--- a/cabot/cabotapp/migrations/0038_auto__add_field_statuscheck_run_delay.py
+++ b/cabot/cabotapp/migrations/0038_auto__add_field_statuscheck_run_delay.py
@@ -1,0 +1,220 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'StatusCheck.run_delay'
+        db.add_column(u'cabotapp_statuscheck', 'run_delay',
+                      self.gf('django.db.models.fields.PositiveIntegerField')(default=0),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'StatusCheck.run_delay'
+        db.delete_column(u'cabotapp_statuscheck', 'run_delay')
+
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'cabotapp.activitycounter': {
+            'Meta': {'object_name': 'ActivityCounter'},
+            'count': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_disabled': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            'last_enabled': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            'status_check': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'activity_counter'", 'unique': 'True', 'to': u"orm['cabotapp.StatusCheck']"})
+        },
+        u'cabotapp.alertplugin': {
+            'Meta': {'object_name': 'AlertPlugin'},
+            'enabled': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'polymorphic_ctype': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'polymorphic_cabotapp.alertplugin_set'", 'null': 'True', 'to': u"orm['contenttypes.ContentType']"}),
+            'title': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'cabotapp.alertpluginuserdata': {
+            'Meta': {'unique_together': "(('title', 'user'),)", 'object_name': 'AlertPluginUserData'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'polymorphic_ctype': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'polymorphic_cabotapp.alertpluginuserdata_set'", 'null': 'True', 'to': u"orm['contenttypes.ContentType']"}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '30'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['cabotapp.UserProfile']"})
+        },
+        u'cabotapp.hipchatinstance': {
+            'Meta': {'object_name': 'HipchatInstance'},
+            'api_v2_key': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '20'}),
+            'server_url': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'cabotapp.httpstatuscheck': {
+            'Meta': {'ordering': "['name']", 'object_name': 'HttpStatusCheck', '_ormbases': [u'cabotapp.StatusCheck']},
+            'allow_http_redirects': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'endpoint': ('django.db.models.fields.TextField', [], {'null': 'True'}),
+            'header_match': ('django.db.models.fields.TextField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'http_body': ('django.db.models.fields.TextField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'http_method': ('django.db.models.fields.CharField', [], {'default': "'GET'", 'max_length': '10'}),
+            'http_params': ('django.db.models.fields.TextField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'password': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'status_code': ('django.db.models.fields.TextField', [], {'default': '200', 'null': 'True'}),
+            u'statuscheck_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['cabotapp.StatusCheck']", 'unique': 'True', 'primary_key': 'True'}),
+            'text_match': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'timeout': ('cabot.cabotapp.fields.PositiveIntegerMaxField', [], {'default': '30', 'null': 'True'}),
+            'username': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'verify_ssl_certificate': ('django.db.models.fields.BooleanField', [], {'default': 'True'})
+        },
+        u'cabotapp.jenkinsstatuscheck': {
+            'Meta': {'ordering': "['name']", 'object_name': 'JenkinsStatusCheck', '_ormbases': [u'cabotapp.StatusCheck']},
+            'max_build_failures': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'max_queued_build_time': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            u'statuscheck_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['cabotapp.StatusCheck']", 'unique': 'True', 'primary_key': 'True'})
+        },
+        u'cabotapp.mattermostinstance': {
+            'Meta': {'object_name': 'MatterMostInstance'},
+            'api_token': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'default_channel_id': ('django.db.models.fields.CharField', [], {'max_length': '32', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '20'}),
+            'server_url': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'webhook_url': ('django.db.models.fields.CharField', [], {'max_length': '256'})
+        },
+        u'cabotapp.schedule': {
+            'Meta': {'object_name': 'Schedule'},
+            'fallback_officer': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']", 'null': 'True', 'blank': 'True'}),
+            'ical_url': ('django.db.models.fields.TextField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '50'})
+        },
+        u'cabotapp.scheduleproblems': {
+            'Meta': {'object_name': 'ScheduleProblems'},
+            'schedule': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'problems'", 'unique': 'True', 'primary_key': 'True', 'to': u"orm['cabotapp.Schedule']"}),
+            'silence_warnings_until': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            'text': ('django.db.models.fields.TextField', [], {})
+        },
+        u'cabotapp.service': {
+            'Meta': {'ordering': "['name']", 'object_name': 'Service'},
+            'alerts': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['cabotapp.AlertPlugin']", 'symmetrical': 'False', 'blank': 'True'}),
+            'alerts_enabled': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'email_alert': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'hackpad_id': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'hipchat_alert': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'hipchat_instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['cabotapp.HipchatInstance']", 'null': 'True', 'blank': 'True'}),
+            'hipchat_room_id': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_alert_sent': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'mattermost_channel_id': ('django.db.models.fields.CharField', [], {'max_length': '32', 'null': 'True', 'blank': 'True'}),
+            'mattermost_instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['cabotapp.MatterMostInstance']", 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.TextField', [], {}),
+            'old_overall_status': ('django.db.models.fields.TextField', [], {'default': "'PASSING'"}),
+            'overall_status': ('django.db.models.fields.TextField', [], {'default': "'PASSING'"}),
+            'schedules': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['cabotapp.Schedule']", 'null': 'True', 'blank': 'True'}),
+            'sms_alert': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'status_checks': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['cabotapp.StatusCheck']", 'symmetrical': 'False', 'blank': 'True'}),
+            'telephone_alert': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'url': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'users_to_notify': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.User']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'cabotapp.servicestatussnapshot': {
+            'Meta': {'object_name': 'ServiceStatusSnapshot'},
+            'did_send_alert': ('django.db.models.fields.IntegerField', [], {'default': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'num_checks_active': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'num_checks_failing': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'num_checks_passing': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'overall_status': ('django.db.models.fields.TextField', [], {'default': "'PASSING'"}),
+            'service': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'snapshots'", 'to': u"orm['cabotapp.Service']"}),
+            'time': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True'})
+        },
+        u'cabotapp.shift': {
+            'Meta': {'object_name': 'Shift'},
+            'deleted': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'end': ('django.db.models.fields.DateTimeField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'schedule': ('django.db.models.fields.related.ForeignKey', [], {'default': '1', 'to': u"orm['cabotapp.Schedule']"}),
+            'start': ('django.db.models.fields.DateTimeField', [], {}),
+            'uid': ('django.db.models.fields.TextField', [], {}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']"})
+        },
+        u'cabotapp.statuscheck': {
+            'Meta': {'ordering': "['name']", 'object_name': 'StatusCheck'},
+            'active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'cached_health': ('django.db.models.fields.TextField', [], {'null': 'True'}),
+            'calculated_status': ('django.db.models.fields.CharField', [], {'default': "'passing'", 'max_length': '50', 'blank': 'True'}),
+            'created_by': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']", 'null': 'True'}),
+            'frequency': ('django.db.models.fields.PositiveIntegerField', [], {'default': '5'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'importance': ('django.db.models.fields.CharField', [], {'default': "'ERROR'", 'max_length': '30'}),
+            'last_run': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            'name': ('django.db.models.fields.TextField', [], {}),
+            'polymorphic_ctype': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'polymorphic_cabotapp.statuscheck_set'", 'null': 'True', 'to': u"orm['contenttypes.ContentType']"}),
+            'retries': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0', 'null': 'True'}),
+            'run_delay': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'runbook': ('django.db.models.fields.TextField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'use_activity_counter': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        u'cabotapp.statuscheckresult': {
+            'Meta': {'object_name': 'StatusCheckResult'},
+            'check': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['cabotapp.StatusCheck']"}),
+            'error': ('django.db.models.fields.TextField', [], {'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'job_number': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True'}),
+            'raw_data': ('django.db.models.fields.TextField', [], {'null': 'True'}),
+            'succeeded': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'time': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True'}),
+            'time_complete': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'db_index': 'True'})
+        },
+        u'cabotapp.tcpstatuscheck': {
+            'Meta': {'ordering': "['name']", 'object_name': 'TCPStatusCheck', '_ormbases': [u'cabotapp.StatusCheck']},
+            'address': ('django.db.models.fields.CharField', [], {'max_length': '1024'}),
+            'port': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            u'statuscheck_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['cabotapp.StatusCheck']", 'unique': 'True', 'primary_key': 'True'}),
+            'timeout': ('cabot.cabotapp.fields.PositiveIntegerMaxField', [], {'default': '8'})
+        },
+        u'cabotapp.userprofile': {
+            'Meta': {'object_name': 'UserProfile'},
+            'hipchat_alias': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '50', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'mobile_number': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '20', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'profile'", 'unique': 'True', 'to': u"orm['auth.User']"})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        }
+    }
+
+    complete_apps = ['cabotapp']

--- a/cabot/cabotapp/models.py
+++ b/cabot/cabotapp/models.py
@@ -483,13 +483,11 @@ class StatusCheck(PolymorphicModel):
 
         # Handle special cases for activity-counted checks, which may have run delays
         if self.use_activity_counter:
-            counters = ActivityCounter.objects.filter(status_check=self)
-
-            # If the check's activity counter doesn't exist, the check should not run
-            if len(counters) == 0:
+            # Get the check's counter. If it doesn't exist, the check should not run.
+            try:
+                counter = ActivityCounter.objects.get(status_check=self)
+            except ActivityCounter.DoesNotExist:
                 return False
-
-            counter = counters[0]
 
             # If last_enabled is None, then either:
             # - If count == 0, the check should not run, as there is no record of the counter being incremented.

--- a/cabot/cabotapp/models.py
+++ b/cabot/cabotapp/models.py
@@ -485,14 +485,12 @@ class StatusCheck(PolymorphicModel):
         if self.use_activity_counter:
             counters = ActivityCounter.objects.filter(status_check=self)
 
-            # SPECIAL CASE #1:
             # If the check's activity counter doesn't exist, the check should not run
             if len(counters) == 0:
                 return False
 
             counter = counters[0]
 
-            # SPECIAL CASE #2:
             # If last_enabled is None, then either:
             # - If count == 0, the check should not run, as there is no record of the counter being incremented.
             # - If count > 0, set last_enabled to now to ensure it is not None. This should only happen once,
@@ -513,8 +511,8 @@ class StatusCheck(PolymorphicModel):
             #
             #      (last_enabled+run_delay) <= current_time <= (last_disabled+run_delay)
             #
-            # Note that we don't need to check the counter value; it is used elsewhere when setting
-            # last_enabled and last_disabled.
+            # Note that we don't need to check the counter value; it is used by ActivityCounter instance
+            # methods to determine when to update last_enabled and last_disabled.
             mins_delay = timedelta(minutes=self.run_delay)
             window_start = counter.last_enabled + mins_delay
             window_end = (counter.last_disabled + mins_delay) if counter.last_disabled else None

--- a/cabot/cabotapp/models.py
+++ b/cabot/cabotapp/models.py
@@ -493,8 +493,11 @@ class StatusCheck(PolymorphicModel):
 
             # last_enabled may be None when this change is first deployed. Set it to now and log a warning.
             if counter.last_enabled is None:
+                # NB: since we are updating last_enabled outside of a transaction, there's a possibility
+                # that we clobber existing data. However, we should almost never enter this if-block, and
+                # worst case we clobber a recent value with a nearly identical value.
                 counter.last_enabled = timezone.now()
-                counter.save()
+                counter.save(update_fields=["last_enabled"])
                 logger.warning("activity_counter id={} last_enabled is None, setting to now".format(counter.id))
 
             # Compute the window during which checks may run, as the last_enable/disabled times,

--- a/cabot/cabotapp/tests/test_api.py
+++ b/cabot/cabotapp/tests/test_api.py
@@ -541,20 +541,21 @@ class TestActivityCounterAPI(APITransactionTestCase):
         self.assertIsNone(counter.last_enabled)
 
         # Because use_activity_counter is False, should_run() will not set last_enabled
-        check.should_run()
+        self.http_check.should_run()
         self.assertIsNone(counter.last_enabled)
 
         # Enable activity counters. Because the count is zero, we still will not set last_enabled
         self.http_check.use_activity_counter = True
         self.http_check.save()
         self.assertEqual(counter.count, 0)
-        check.should_run()
+        self.http_check.should_run()
         self.assertIsNone(counter.last_enabled)
 
         # Once count is positive and we need last_enabled, it'll be set
         counter.count = 4
         counter.save()
-        check.should_run()
+        self.http_check.should_run()
+        counter = self._get_activity_counter()
         self.assertIsNotNone(counter.last_enabled)
 
     def test_check_should_not_run_when_activity_counter_missing(self):

--- a/cabot/cabotapp/tests/test_api.py
+++ b/cabot/cabotapp/tests/test_api.py
@@ -533,6 +533,9 @@ class TestActivityCounterAPI(APITransactionTestCase):
         self.assertFalse(self.http_check.should_run())
 
     def test_check_should_run_should_set_last_enabled_if_null(self):
+        # This tests the behavior of should_run(), and under what circumstances
+        # it should set the last_enabled field.
+
         # Create the activity_counter
         self._set_activity_counter(False, 0)
         counter = self._get_activity_counter()
@@ -541,20 +544,20 @@ class TestActivityCounterAPI(APITransactionTestCase):
         self.assertIsNone(counter.last_enabled)
 
         # Because use_activity_counter is False, should_run() will not set last_enabled
-        self.http_check.should_run()
+        self.assertTrue(self.http_check.should_run())
         self.assertIsNone(counter.last_enabled)
 
         # Enable activity counters. Because the count is zero, we still will not set last_enabled
         self.http_check.use_activity_counter = True
         self.http_check.save()
         self.assertEqual(counter.count, 0)
-        self.http_check.should_run()
+        self.assertFalse(self.http_check.should_run())
         self.assertIsNone(counter.last_enabled)
 
         # Once count is positive and we need last_enabled, it'll be set
         counter.count = 4
         counter.save()
-        self.http_check.should_run()
+        self.assertTrue(self.http_check.should_run())
         counter = self._get_activity_counter()
         self.assertIsNotNone(counter.last_enabled)
 

--- a/cabot/cabotapp/tests/test_api.py
+++ b/cabot/cabotapp/tests/test_api.py
@@ -581,9 +581,8 @@ class TestActivityCounterAPI(APITransactionTestCase):
 
         # Finally, reset the counter and set the last_disabled time to last_enabled + 60.
         # The check should not run if after the disabled time (last_enabled + 90).
-        counter.last_disabled = counter.last_enabled + timedelta(minutes=60)
-        counter.count = 0
-        counter.save()
+        mock_now.return_value = counter.last_enabled + timedelta(minutes=60)
+        counter.reset_and_save()
 
         # - Though the counter is 0, the current time is still less than last_disabled + run_delay,
         #   so the check should still run.

--- a/cabot/cabotapp/tests/utils.py
+++ b/cabot/cabotapp/tests/utils.py
@@ -10,7 +10,6 @@ from datetime import timedelta
 import json
 import os
 import socket
-from celery.task import task
 from mock import Mock
 
 from cabot.cabotapp.models import (
@@ -190,12 +189,6 @@ def fake_calendar(*args, **kwargs):
     resp = Mock()
     resp.content = get_content(args)
     resp.status_code = 200
-    return resp
-
-
-@task(ignore_result=True)
-def fake_run_status_check(*args, **kwargs):
-    resp = Mock()
     return resp
 
 

--- a/cabot/cabotapp/views.py
+++ b/cabot/cabotapp/views.py
@@ -191,7 +191,8 @@ class HttpStatusCheckForm(StatusCheckForm):
             ('Request', ('endpoint', 'frequency', 'retries', 'http_method', 'http_params', 'http_body')),
             ('Response Validation', ('status_code', 'text_match', 'header_match', 'timeout')),
             ('Authentication', ('username', 'password')),
-            ('Advanced', ('allow_http_redirects', 'verify_ssl_certificate', 'use_activity_counter', 'runbook')),
+            ('Advanced', ('allow_http_redirects', 'verify_ssl_certificate', 'use_activity_counter', 'run_delay',
+                          'runbook')),
         )
         widgets = dict(**base_widgets)
         widgets.update({
@@ -233,7 +234,7 @@ class TCPStatusCheckForm(StatusCheckForm):
         grouped_fields = (
             ('Basic', ('name', 'active', 'importance', 'service_set')),
             ('TCP', ('address', 'port', 'timeout', 'frequency', 'retries')),
-            ('Advanced', ('use_activity_counter', 'runbook')),
+            ('Advanced', ('use_activity_counter', 'run_delay', 'runbook')),
         )
         widgets = dict(**base_widgets)
         widgets.update({

--- a/cabot/cabotapp/views.py
+++ b/cabot/cabotapp/views.py
@@ -223,7 +223,7 @@ class JenkinsStatusCheckForm(StatusCheckForm):
         grouped_fields = (
             ('Basic', ('name', 'active', 'importance', 'service_set')),
             ('Jenkins', ('max_queued_build_time', 'max_build_failures', 'retries')),
-            ('Advanced', ('use_activity_counter', 'runbook')),
+            ('Advanced', ('use_activity_counter', 'run_delay', 'runbook')),
         )
         widgets = dict(**base_widgets)
 

--- a/cabot/cabotapp/views.py
+++ b/cabot/cabotapp/views.py
@@ -862,6 +862,7 @@ class ActivityCounterView(View):
         data = {
             'check.id': check.id,
             'check.name': check.name,
+            'check.run_delay': check.run_delay,
             'counter.count': counter.count,
             'counter.enabled': check.use_activity_counter,
             'counter.last_enabled': format_datetime(counter.last_enabled),

--- a/cabot/metricsapp/forms/elastic.py
+++ b/cabot/metricsapp/forms/elastic.py
@@ -42,6 +42,7 @@ class ElasticsearchStatusCheckForm(StatusCheckForm):
             'retries',
             'ignore_final_data_point',
             'use_activity_counter',
+            'run_delay',
             'runbook',
         )
 

--- a/cabot/metricsapp/forms/grafana_elastic.py
+++ b/cabot/metricsapp/forms/grafana_elastic.py
@@ -29,6 +29,7 @@ _GROUPS = (
     ('Advanced', (
         'auto_sync',
         'use_activity_counter',
+        'run_delay',
         'runbook',
     )),
 )

--- a/cabot/metricsapp/tests/test_views.py
+++ b/cabot/metricsapp/tests/test_views.py
@@ -33,7 +33,6 @@ class TestMetricsReviewChanges(TestCase):
             'auto_sync': True,
             'check_type': '<=',
             'warning_value': 9.0,
-
             'high_alert_importance': Service.ERROR_STATUS,
             'high_alert_value': 15.0,
             'consecutive_failures': 1,
@@ -43,6 +42,7 @@ class TestMetricsReviewChanges(TestCase):
             'ignore_final_data_point': True,
             'on_empty_series': 'fill_zero',
             'use_activity_counter': False,
+            'run_delay': 0,
             'runbook': '',
         }
 

--- a/conf/development.env.example
+++ b/conf/development.env.example
@@ -60,6 +60,10 @@ AUTH_LDAP_BIND_PASSWORD=""
 AUTH_LDAP_USER_SEARCH="ou=People,dc=example,dc=com"
 
 CELERY_RATE_LIMIT=15/s
+
+# Controls whether tasks are executed locally ('eager') or via the message broker.
+# NB: setting CELERY_ALWAYS_EAGER=False will NOT work! You must comment out or remove
+#     this environment variable completely!
 CELERY_ALWAYS_EAGER=True
 
 TEST_OUTPUT_DIR=./build/test-psql


### PR DESCRIPTION
Second attempt at adding a run delay to status checks.  First attempt can be seen in [this PR](https://github.com/Affirm/cabot/pull/162).

This PR relies on adding the `last_enabled` and `last_disabled` fields to the `ActivityCounter` model via [this PR](https://github.com/Affirm/cabot/pull/166).

The basic idea is to modify `StatusCheck.should_run()` in the following way:

- For non-activity-counted checks:
  - Use existing logic, i.e. look at the last time the check ran.
- For activity-counted checks:
  - Take the last_enabled and last_disabled times, and move them forward in time by the run_delay. This future window determines the times at which the check can run.
  - We then check if the current time falls within the window, and if the check has not run recently.  If so, we the check can run.

Note that this implementation does not rely on the `countdown` kward to `task.apply_async()`.

Two things:

1. I still need to test this!
2. This PR diffs against the more-activity-counter-fields branch and not master.