### PR TITLE
More activity counter fields

### DIFF
--- a/cabot/cabotapp/migrations/0037_auto__add_field_activitycounter_last_enabled__add_field_activitycounte.py
+++ b/cabot/cabotapp/migrations/0037_auto__add_field_activitycounter_last_enabled__add_field_activitycounte.py
@@ -1,0 +1,227 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'ActivityCounter.last_enabled'
+        db.add_column(u'cabotapp_activitycounter', 'last_enabled',
+                      self.gf('django.db.models.fields.DateTimeField')(null=True),
+                      keep_default=False)
+
+        # Adding field 'ActivityCounter.last_disabled'
+        db.add_column(u'cabotapp_activitycounter', 'last_disabled',
+                      self.gf('django.db.models.fields.DateTimeField')(null=True),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'ActivityCounter.last_enabled'
+        db.delete_column(u'cabotapp_activitycounter', 'last_enabled')
+
+        # Deleting field 'ActivityCounter.last_disabled'
+        db.delete_column(u'cabotapp_activitycounter', 'last_disabled')
+
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'cabotapp.activitycounter': {
+            'Meta': {'object_name': 'ActivityCounter'},
+            'count': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_disabled': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            'last_enabled': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            'status_check': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'activity_counter'", 'unique': 'True', 'to': u"orm['cabotapp.StatusCheck']"})
+        },
+        u'cabotapp.alertplugin': {
+            'Meta': {'object_name': 'AlertPlugin'},
+            'enabled': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'polymorphic_ctype': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'polymorphic_cabotapp.alertplugin_set'", 'null': 'True', 'to': u"orm['contenttypes.ContentType']"}),
+            'title': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'cabotapp.alertpluginuserdata': {
+            'Meta': {'unique_together': "(('title', 'user'),)", 'object_name': 'AlertPluginUserData'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'polymorphic_ctype': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'polymorphic_cabotapp.alertpluginuserdata_set'", 'null': 'True', 'to': u"orm['contenttypes.ContentType']"}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '30'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['cabotapp.UserProfile']"})
+        },
+        u'cabotapp.hipchatinstance': {
+            'Meta': {'object_name': 'HipchatInstance'},
+            'api_v2_key': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '20'}),
+            'server_url': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'cabotapp.httpstatuscheck': {
+            'Meta': {'ordering': "['name']", 'object_name': 'HttpStatusCheck', '_ormbases': [u'cabotapp.StatusCheck']},
+            'allow_http_redirects': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'endpoint': ('django.db.models.fields.TextField', [], {'null': 'True'}),
+            'header_match': ('django.db.models.fields.TextField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'http_body': ('django.db.models.fields.TextField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'http_method': ('django.db.models.fields.CharField', [], {'default': "'GET'", 'max_length': '10'}),
+            'http_params': ('django.db.models.fields.TextField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'password': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'status_code': ('django.db.models.fields.TextField', [], {'default': '200', 'null': 'True'}),
+            u'statuscheck_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['cabotapp.StatusCheck']", 'unique': 'True', 'primary_key': 'True'}),
+            'text_match': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'timeout': ('cabot.cabotapp.fields.PositiveIntegerMaxField', [], {'default': '30', 'null': 'True'}),
+            'username': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'verify_ssl_certificate': ('django.db.models.fields.BooleanField', [], {'default': 'True'})
+        },
+        u'cabotapp.jenkinsstatuscheck': {
+            'Meta': {'ordering': "['name']", 'object_name': 'JenkinsStatusCheck', '_ormbases': [u'cabotapp.StatusCheck']},
+            'max_build_failures': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'max_queued_build_time': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            u'statuscheck_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['cabotapp.StatusCheck']", 'unique': 'True', 'primary_key': 'True'})
+        },
+        u'cabotapp.mattermostinstance': {
+            'Meta': {'object_name': 'MatterMostInstance'},
+            'api_token': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'default_channel_id': ('django.db.models.fields.CharField', [], {'max_length': '32', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '20'}),
+            'server_url': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'webhook_url': ('django.db.models.fields.CharField', [], {'max_length': '256'})
+        },
+        u'cabotapp.schedule': {
+            'Meta': {'object_name': 'Schedule'},
+            'fallback_officer': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']", 'null': 'True', 'blank': 'True'}),
+            'ical_url': ('django.db.models.fields.TextField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '50'})
+        },
+        u'cabotapp.scheduleproblems': {
+            'Meta': {'object_name': 'ScheduleProblems'},
+            'schedule': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'problems'", 'unique': 'True', 'primary_key': 'True', 'to': u"orm['cabotapp.Schedule']"}),
+            'silence_warnings_until': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            'text': ('django.db.models.fields.TextField', [], {})
+        },
+        u'cabotapp.service': {
+            'Meta': {'ordering': "['name']", 'object_name': 'Service'},
+            'alerts': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['cabotapp.AlertPlugin']", 'symmetrical': 'False', 'blank': 'True'}),
+            'alerts_enabled': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'email_alert': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'hackpad_id': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'hipchat_alert': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'hipchat_instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['cabotapp.HipchatInstance']", 'null': 'True', 'blank': 'True'}),
+            'hipchat_room_id': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_alert_sent': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'mattermost_channel_id': ('django.db.models.fields.CharField', [], {'max_length': '32', 'null': 'True', 'blank': 'True'}),
+            'mattermost_instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['cabotapp.MatterMostInstance']", 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.TextField', [], {}),
+            'old_overall_status': ('django.db.models.fields.TextField', [], {'default': "'PASSING'"}),
+            'overall_status': ('django.db.models.fields.TextField', [], {'default': "'PASSING'"}),
+            'schedules': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['cabotapp.Schedule']", 'null': 'True', 'blank': 'True'}),
+            'sms_alert': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'status_checks': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['cabotapp.StatusCheck']", 'symmetrical': 'False', 'blank': 'True'}),
+            'telephone_alert': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'url': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'users_to_notify': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.User']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'cabotapp.servicestatussnapshot': {
+            'Meta': {'object_name': 'ServiceStatusSnapshot'},
+            'did_send_alert': ('django.db.models.fields.IntegerField', [], {'default': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'num_checks_active': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'num_checks_failing': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'num_checks_passing': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'overall_status': ('django.db.models.fields.TextField', [], {'default': "'PASSING'"}),
+            'service': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'snapshots'", 'to': u"orm['cabotapp.Service']"}),
+            'time': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True'})
+        },
+        u'cabotapp.shift': {
+            'Meta': {'object_name': 'Shift'},
+            'deleted': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'end': ('django.db.models.fields.DateTimeField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'schedule': ('django.db.models.fields.related.ForeignKey', [], {'default': '1', 'to': u"orm['cabotapp.Schedule']"}),
+            'start': ('django.db.models.fields.DateTimeField', [], {}),
+            'uid': ('django.db.models.fields.TextField', [], {}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']"})
+        },
+        u'cabotapp.statuscheck': {
+            'Meta': {'ordering': "['name']", 'object_name': 'StatusCheck'},
+            'active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'cached_health': ('django.db.models.fields.TextField', [], {'null': 'True'}),
+            'calculated_status': ('django.db.models.fields.CharField', [], {'default': "'passing'", 'max_length': '50', 'blank': 'True'}),
+            'created_by': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']", 'null': 'True'}),
+            'frequency': ('django.db.models.fields.PositiveIntegerField', [], {'default': '5'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'importance': ('django.db.models.fields.CharField', [], {'default': "'ERROR'", 'max_length': '30'}),
+            'last_run': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            'name': ('django.db.models.fields.TextField', [], {}),
+            'polymorphic_ctype': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'polymorphic_cabotapp.statuscheck_set'", 'null': 'True', 'to': u"orm['contenttypes.ContentType']"}),
+            'retries': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0', 'null': 'True'}),
+            'runbook': ('django.db.models.fields.TextField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'use_activity_counter': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        u'cabotapp.statuscheckresult': {
+            'Meta': {'object_name': 'StatusCheckResult'},
+            'check': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['cabotapp.StatusCheck']"}),
+            'error': ('django.db.models.fields.TextField', [], {'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'job_number': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True'}),
+            'raw_data': ('django.db.models.fields.TextField', [], {'null': 'True'}),
+            'succeeded': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'time': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True'}),
+            'time_complete': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'db_index': 'True'})
+        },
+        u'cabotapp.tcpstatuscheck': {
+            'Meta': {'ordering': "['name']", 'object_name': 'TCPStatusCheck', '_ormbases': [u'cabotapp.StatusCheck']},
+            'address': ('django.db.models.fields.CharField', [], {'max_length': '1024'}),
+            'port': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            u'statuscheck_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['cabotapp.StatusCheck']", 'unique': 'True', 'primary_key': 'True'}),
+            'timeout': ('cabot.cabotapp.fields.PositiveIntegerMaxField', [], {'default': '8'})
+        },
+        u'cabotapp.userprofile': {
+            'Meta': {'object_name': 'UserProfile'},
+            'hipchat_alias': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '50', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'mobile_number': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '20', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'profile'", 'unique': 'True', 'to': u"orm['auth.User']"})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        }
+    }
+
+    complete_apps = ['cabotapp']

--- a/cabot/cabotapp/models.py
+++ b/cabot/cabotapp/models.py
@@ -14,6 +14,7 @@ from cabot.cabotapp.models_plugins import (  # noqa (unused, imported for side e
 )
 from cabot.cabotapp import defs
 from cabot.cabotapp.fields import PositiveIntegerMaxField
+import cabot.cabotapp.utils
 
 from collections import defaultdict
 from datetime import timedelta
@@ -578,6 +579,27 @@ class ActivityCounter(models.Model):
         related_name='activity_counter',
     )
     count = models.PositiveIntegerField(default=0)
+    last_enabled = models.DateTimeField(null=True)
+    last_disabled = models.DateTimeField(null=True)
+
+    def increment_and_save(self):
+        if self.count == 0:
+            self.last_enabled = cabot.cabotapp.utils.datetime_now()
+        self.count += 1
+        self.save()
+
+    def decrement_and_save(self):
+        if self.count == 1:
+            self.last_disabled = cabot.cabotapp.utils.datetime_now()
+        if self.count > 0:
+            self.count -= 1
+            self.save()
+
+    def reset_and_save(self):
+        if self.count > 0:
+            self.last_disabled = cabot.cabotapp.utils.datetime_now()
+            self.count = 0
+            self.save()
 
 
 class HttpStatusCheck(StatusCheck):

--- a/cabot/cabotapp/models.py
+++ b/cabot/cabotapp/models.py
@@ -14,7 +14,6 @@ from cabot.cabotapp.models_plugins import (  # noqa (unused, imported for side e
 )
 from cabot.cabotapp import defs
 from cabot.cabotapp.fields import PositiveIntegerMaxField
-import cabot.cabotapp.utils
 
 from collections import defaultdict
 from datetime import timedelta
@@ -584,20 +583,20 @@ class ActivityCounter(models.Model):
 
     def increment_and_save(self):
         if self.count == 0:
-            self.last_enabled = cabot.cabotapp.utils.datetime_now()
+            self.last_enabled = timezone.now()
         self.count += 1
         self.save()
 
     def decrement_and_save(self):
         if self.count == 1:
-            self.last_disabled = cabot.cabotapp.utils.datetime_now()
+            self.last_disabled = timezone.now()
         if self.count > 0:
             self.count -= 1
             self.save()
 
     def reset_and_save(self):
         if self.count > 0:
-            self.last_disabled = cabot.cabotapp.utils.datetime_now()
+            self.last_disabled = timezone.now()
             self.count = 0
             self.save()
 

--- a/cabot/cabotapp/tests/test_api.py
+++ b/cabot/cabotapp/tests/test_api.py
@@ -395,9 +395,9 @@ class TestActivityCounterAPI(APITransactionTestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
 
-    @patch('cabot.cabotapp.utils.datetime_now')
-    def test_counter_incr(self, mock_datetime_now):
-        mock_datetime_now.return_value = self.LAST_ENABLED_TIME
+    @patch('cabot.cabotapp.models.timezone.now')
+    def test_counter_incr(self, mock_now):
+        mock_now.return_value = self.LAST_ENABLED_TIME
         self._set_activity_counter(True, 0)
         url = '/api/status-checks/activity-counter?id=10102'
         expected_body = {
@@ -421,9 +421,9 @@ class TestActivityCounterAPI(APITransactionTestCase):
         self.assertEqual(json.loads(response.content), expected_body)
         self.assertEqual(StatusCheck.objects.filter(id=10102)[0].activity_counter.count, 1)
 
-    @patch('cabot.cabotapp.utils.datetime_now')
-    def test_counter_decr(self, mock_datetime_now):
-        mock_datetime_now.return_value = self.LAST_DISABLED_TIME
+    @patch('cabot.cabotapp.models.timezone.now')
+    def test_counter_decr(self, mock_now):
+        mock_now.return_value = self.LAST_DISABLED_TIME
         self._set_activity_counter(True, 2)
         url = '/api/status-checks/activity-counter?id=10102&action=decr'
         expected_body = {
@@ -453,9 +453,9 @@ class TestActivityCounterAPI(APITransactionTestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(json.loads(response.content), expected_body)
 
-    @patch('cabot.cabotapp.utils.datetime_now')
-    def test_counter_reset(self, mock_datetime_now):
-        mock_datetime_now.return_value = self.LAST_DISABLED_TIME
+    @patch('cabot.cabotapp.models.timezone.now')
+    def test_counter_reset(self, mock_now):
+        mock_now.return_value = self.LAST_DISABLED_TIME
         self._set_activity_counter(True, 11)
         url = '/api/status-checks/activity-counter?id=10102&action=reset'
         expected_body = {

--- a/cabot/cabotapp/tests/test_status_check.py
+++ b/cabot/cabotapp/tests/test_status_check.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
 
-from datetime import timedelta
+from datetime import timedelta, datetime
 from django.core.exceptions import ValidationError
+from django.test import TestCase
 from django.utils import timezone
 from cabot.cabotapp import tasks
 from mock import patch
-from cabot.cabotapp.models import HttpStatusCheck, Service, clone_model
+from cabot.cabotapp.models import HttpStatusCheck, Service, clone_model, ActivityCounter
 from cabot.cabotapp.tasks import update_service, update_all_services
 from .utils import (
     LocalTestCase,
@@ -281,3 +282,81 @@ class TestStatusCheck(LocalTestCase):
         check_2.use_activity_counter = False
         check_2.save()
         check_1.clean()
+
+
+class TestActivityCounter(TestCase):
+
+    def setUp(self):
+        self.counter = ActivityCounter()
+
+    def test_activity_counter_defaults(self):
+        self.assertEqual(self.counter.count, 0)
+        self.assertIsNone(self.counter.last_enabled)
+        self.assertIsNone(self.counter.last_disabled)
+
+    @patch('cabot.cabotapp.models.ActivityCounter.save')
+    @patch('cabot.cabotapp.models.timezone.now')
+    def test_activity_counter_increment_and_save(self, mock_now, mock_save):
+        now1 = datetime(2018, 12, 10, 1, 1, 1)
+        now2 = datetime(2018, 12, 10, 2, 2, 2)
+
+        # First increment sets last_enabled
+        mock_now.return_value = now1
+        self.counter.increment_and_save()
+        self.assertEqual(self.counter.count, 1)
+        self.assertEqual(self.counter.last_enabled, now1)
+        self.assertIsNone(self.counter.last_disabled)
+        self.assertEqual(mock_save.call_count, 1)
+
+        # Second call increments counter, last_enabled stays the same
+        mock_now.return_value = now2
+        self.counter.increment_and_save()
+        self.assertEqual(self.counter.count, 2)
+        self.assertEqual(self.counter.last_enabled, now1)
+        self.assertEqual(mock_save.call_count, 2)
+
+    @patch('cabot.cabotapp.models.ActivityCounter.save')
+    @patch('cabot.cabotapp.models.timezone.now')
+    def test_activity_counter_decrement_and_save(self, mock_now, mock_save):
+        now = datetime(2018, 12, 10, 1, 1, 1)
+        mock_now.return_value = now
+
+        # At counter of 0, nothing happens
+        self.counter.decrement_and_save()
+        self.assertEqual(self.counter.count, 0)
+        self.assertIsNone(self.counter.last_enabled)
+        self.assertIsNone(self.counter.last_disabled)
+        self.assertEqual(mock_now.call_count, 0)
+        self.assertEqual(mock_save.call_count, 0)
+
+        # At count of 1, decrement and set last_disabled
+        self.counter.count = 1
+        self.counter.decrement_and_save()
+        self.assertEqual(self.counter.count, 0)
+        self.assertIsNone(self.counter.last_enabled)
+        self.assertEqual(self.counter.last_disabled, now)
+        self.assertEqual(mock_now.call_count, 1)
+        self.assertEqual(mock_save.call_count, 1)
+
+    @patch('cabot.cabotapp.models.ActivityCounter.save')
+    @patch('cabot.cabotapp.models.timezone.now')
+    def test_activity_counter_reset_and_save(self, mock_now, mock_save):
+        now = datetime(2018, 12, 10, 1, 1, 1)
+        mock_now.return_value = now
+
+        # At counter of 0, nothing happens
+        self.counter.reset_and_save()
+        self.assertEqual(self.counter.count, 0)
+        self.assertIsNone(self.counter.last_enabled)
+        self.assertIsNone(self.counter.last_disabled)
+        self.assertEqual(mock_now.call_count, 0)
+        self.assertEqual(mock_save.call_count, 0)
+
+        # At positive count, update counter and last_disabled
+        self.counter.count = 42
+        self.counter.reset_and_save()
+        self.assertEqual(self.counter.count, 0)
+        self.assertIsNone(self.counter.last_enabled)
+        self.assertEqual(self.counter.last_disabled, now)
+        self.assertEqual(mock_now.call_count, 1)
+        self.assertEqual(mock_save.call_count, 1)

--- a/cabot/cabotapp/utils.py
+++ b/cabot/cabotapp/utils.py
@@ -1,6 +1,17 @@
 from django.conf import settings
+from datetime import datetime
 
 
 def build_absolute_url(relative_url):
     """Prepend https?://host to a url, useful for links going into emails"""
     return '{}://{}{}'.format(settings.WWW_SCHEME, settings.WWW_HTTP_HOST, relative_url)
+
+
+def format_datetime(dt):
+    '''Convert datetime to string. None is converted to empty string.'''
+    return '' if dt is None else datetime.strftime(dt, '%Y-%m-%d %H:%M:%S')
+
+
+def datetime_now():
+    '''Wrapper around datetime.now(). Needed for mocking.'''
+    return datetime.now()

--- a/cabot/cabotapp/utils.py
+++ b/cabot/cabotapp/utils.py
@@ -10,8 +10,3 @@ def build_absolute_url(relative_url):
 def format_datetime(dt):
     '''Convert datetime to string. None is converted to empty string.'''
     return '' if dt is None else datetime.strftime(dt, '%Y-%m-%d %H:%M:%S')
-
-
-def datetime_now():
-    '''Wrapper around datetime.now(). Needed for mocking.'''
-    return datetime.now()

--- a/cabot/cabotapp/views.py
+++ b/cabot/cabotapp/views.py
@@ -40,6 +40,7 @@ from django.core.exceptions import ValidationError
 from django.db import transaction
 
 from cabot.cabotapp import alert
+from cabot.cabotapp.utils import format_datetime
 from models import AlertPluginUserData
 from django.contrib import messages
 from social.exceptions import AuthFailed
@@ -862,6 +863,8 @@ class ActivityCounterView(View):
             'check.name': check.name,
             'counter.count': counter.count,
             'counter.enabled': check.use_activity_counter,
+            'counter.last_enabled': format_datetime(counter.last_enabled),
+            'counter.last_disabled': format_datetime(counter.last_disabled),
         }
         if message:
             data['detail'] = message
@@ -894,20 +897,15 @@ class ActivityCounterView(View):
             return None
 
         if action == 'incr':
-            counter.count += 1
-            counter.save()
+            counter.increment_and_save()
             return 'counter incremented to {}'.format(counter.count)
 
         if action == 'decr':
-            if counter.count > 0:
-                counter.count -= 1
-                counter.save()
+            counter.decrement_and_save()
             return 'counter decremented to {}'.format(counter.count)
 
         if action == 'reset':
-            if counter.count > 0:
-                counter.count = 0
-                counter.save()
+            counter.reset_and_save()
             return 'counter reset to 0'
 
         raise ViewError("invalid action '{}'".format(action), 400)


### PR DESCRIPTION
Add `last_enabled` and `last_disabled` fields to the `ActivityCounter` model.  These fields will be populated as the counter is incremented and decremented. They provide a small level of observability into the most recent state changes of the counter, but are also a precursor for implementing a run-delay via [this PR](https://github.com/Affirm/cabot/pull/165).