### PR TITLE
Retry ElasticSearch queries on timeout

### DIFF
--- a/cabot/metricsapp/api/elastic.py
+++ b/cabot/metricsapp/api/elastic.py
@@ -24,7 +24,7 @@ def create_es_client(urls, timeout=settings.ELASTICSEARCH_TIMEOUT):
     :return: a new elasticsearch-py client
     """
     urls = [url.strip() for url in urls.split(',')]
-    return Elasticsearch(urls, timeout=timeout)
+    return Elasticsearch(urls, timeout=timeout, retry_on_timeout=True)
 
 
 def validate_query(query, msg_prefix=defs.ES_VALIDATION_MSG_PREFIX):


### PR DESCRIPTION
We've been having some transient issues where Cabot alerts time out connecting to ES. Reading through [the docs](https://elasticsearch-py.readthedocs.io/en/master/index.html?highlight=retry#automatic-retries), timeouts are considered a special case and do not retry by default. This PR turns on retries.

This could have bad effects - if ES is down, this could leave a ton of tasks hanging...maybe lower the timeout from `30s` to `15s`?