### PR TITLE
Gather additional data for derivatives and moving averages

### DIFF
--- a/cabot/metricsapp/api/grafana_elastic.py
+++ b/cabot/metricsapp/api/grafana_elastic.py
@@ -367,7 +367,8 @@ def _get_date_histogram(query):
     for k, v in next_level.iteritems():
         if k == 'date_histogram':
             return v
-        return _get_date_histogram(next_level)
+
+    return _get_date_histogram(next_level)
 
 
 def _adjust_extended_bounds(date_histogram, minimum):

--- a/cabot/metricsapp/tests/fixtures/elastic/grafana/query_builder/grafana_adjusted_derivative_query.json
+++ b/cabot/metricsapp/tests/fixtures/elastic/grafana/query_builder/grafana_adjusted_derivative_query.json
@@ -11,7 +11,7 @@
         {
           "range": {
             "@timestamp": {
-              "gte": "now-3h"
+              "gte": "now-181m"
             }
           }
         }
@@ -34,7 +34,7 @@
             "interval": "1m",
             "extended_bounds": {
               "max": "now",
-              "min": "now-3h"
+              "min": "now-181m"
             }
           },
           "aggs": {

--- a/cabot/metricsapp/tests/fixtures/elastic/grafana/query_builder/grafana_adjusted_moving_avg_query.json
+++ b/cabot/metricsapp/tests/fixtures/elastic/grafana/query_builder/grafana_adjusted_moving_avg_query.json
@@ -1,0 +1,48 @@
+{
+  "query": {
+    "bool": {
+      "must": [
+        {
+          "query_string": {
+            "analyze_wildcard": true,
+            "query": "link.zelda"
+          }
+        },
+        {
+          "range": {
+            "@timestamp": {
+              "gte": "now-230m"
+            }
+          }
+        }
+      ]
+    }
+  },
+  "aggs": {
+    "agg": {
+      "date_histogram": {
+        "field": "@timestamp",
+        "interval": "5m",
+        "extended_bounds": {
+          "max": "now",
+          "min": "now-230m"
+        }
+      },
+      "aggs": {
+        "moving_avg": {
+          "moving_avg": {
+            "buckets_path": "sum_hidethismetric",
+            "minimize": false,
+            "model": "linear",
+            "window": 10
+          }
+        },
+        "sum_hidethismetric": {
+          "sum": {
+            "field": "count"
+          }
+        }
+      }
+    }
+  }
+}

--- a/cabot/metricsapp/tests/fixtures/elastic/grafana/query_builder/grafana_moving_avg.json
+++ b/cabot/metricsapp/tests/fixtures/elastic/grafana/query_builder/grafana_moving_avg.json
@@ -1,0 +1,40 @@
+{
+  "bucketAggs": [
+    {
+      "field": "@timestamp",
+      "id": "2",
+      "settings": {
+        "interval": "5m",
+        "min_doc_count": 0,
+        "trimEdges": 0
+      },
+      "type": "date_histogram"
+    }
+  ],
+  "dsType": "elasticsearch",
+  "metrics": [
+    {
+      "field": "count",
+      "hide": true,
+      "id": "1",
+      "meta": {},
+      "settings": {},
+      "type": "sum"
+    },
+    {
+      "field": "1",
+      "id": "3",
+      "meta": {},
+      "pipelineAgg": "1",
+      "settings": {
+        "minimize": false,
+        "model": "linear",
+        "window": 10 
+      },
+      "type": "moving_avg"
+    }
+  ],
+  "query": "link.zelda",
+  "refId": "A",
+  "timeField": "@timestamp"
+}

--- a/cabot/metricsapp/tests/test_elasticsearch_grafana.py
+++ b/cabot/metricsapp/tests/test_elasticsearch_grafana.py
@@ -106,6 +106,13 @@ class TestGrafanaQueryBuilder(TestCase):
         expected_queries = [get_json_file('grafana/query_builder/grafana_series_query_30m.json')]
         self.assertEqual(new_queries, expected_queries)
 
+    def test_adjust_time_range_derivative(self):
+        series = get_json_file('grafana/query_builder/grafana_derivative.json')
+        created_query = adjust_time_range([build_query(series, min_time='now-3h')], 180)
+        expected_query = get_json_file('grafana/query_builder/grafana_derivative_query.json')
+        self.assertEqual(expected_query, created_query)
+        validate_query(created_query)
+
 
 class TestGrafanaTemplating(TestCase):
     def test_templating(self):

--- a/cabot/metricsapp/tests/test_elasticsearch_grafana.py
+++ b/cabot/metricsapp/tests/test_elasticsearch_grafana.py
@@ -6,6 +6,8 @@ from .test_elasticsearch import get_json_file
 
 
 class TestGrafanaQueryBuilder(TestCase):
+    maxDiff = None
+
     def test_grafana_query(self):
         """Basic query building"""
         series = get_json_file('grafana/query_builder/grafana_series.json')
@@ -43,14 +45,6 @@ class TestGrafanaQueryBuilder(TestCase):
         series = get_json_file('grafana/query_builder/grafana_multiple_metrics.json')
         created_query = build_query(series, min_time='now-30m')
         expected_query = get_json_file('grafana/query_builder/grafana_multiple_metrics_query.json')
-        self.assertEqual(expected_query, created_query)
-        validate_query(created_query)
-
-    def test_derivative(self):
-        """Derivative metric with hidden field"""
-        series = get_json_file('grafana/query_builder/grafana_derivative.json')
-        created_query = build_query(series, min_time='now-3h')
-        expected_query = get_json_file('grafana/query_builder/grafana_derivative_query.json')
         self.assertEqual(expected_query, created_query)
         validate_query(created_query)
 
@@ -106,10 +100,25 @@ class TestGrafanaQueryBuilder(TestCase):
         expected_queries = [get_json_file('grafana/query_builder/grafana_series_query_30m.json')]
         self.assertEqual(new_queries, expected_queries)
 
-    def test_adjust_time_range_derivative(self):
+    def test_derivative_adjusted(self):
+        """
+        Derivative metric with hidden field. Should add 1 * interval (1m) to the time range to
+        prevent issues with partial points being used to calculate the derivative.
+        """
         series = get_json_file('grafana/query_builder/grafana_derivative.json')
-        created_query = adjust_time_range([build_query(series, min_time='now-3h')], 180)
-        expected_query = get_json_file('grafana/query_builder/grafana_derivative_query.json')
+        created_query = adjust_time_range([build_query(series, min_time='now-3h')], 180)[0]
+        expected_query = get_json_file('grafana/query_builder/grafana_adjusted_derivative_query.json')
+        self.assertEqual(expected_query, created_query)
+        validate_query(created_query)
+
+    def test_moving_avg_adjusted(self):
+        """
+        Moving average metric with hidden field. Should add interval (5m) * moving average range (10)
+        to the time range to prevent partial points.
+        """
+        series = get_json_file('grafana/query_builder/grafana_moving_avg.json')
+        created_query = adjust_time_range([build_query(series, min_time='now-3h')], 180)[0]
+        expected_query = get_json_file('grafana/query_builder/grafana_adjusted_moving_avg_query.json')
         self.assertEqual(expected_query, created_query)
         validate_query(created_query)
 

--- a/cabot/settings.py
+++ b/cabot/settings.py
@@ -241,8 +241,8 @@ LOGGING = {
 }
 
 # Disable logging for tests
-# if len(sys.argv) > 1 and sys.argv[1] == 'test':
-#     logging.disable(logging.CRITICAL)
+if len(sys.argv) > 1 and sys.argv[1] == 'test':
+    logging.disable(logging.CRITICAL)
 
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (

--- a/cabot/settings.py
+++ b/cabot/settings.py
@@ -241,8 +241,8 @@ LOGGING = {
 }
 
 # Disable logging for tests
-if len(sys.argv) > 1 and sys.argv[1] == 'test':
-    logging.disable(logging.CRITICAL)
+# if len(sys.argv) > 1 and sys.argv[1] == 'test':
+#     logging.disable(logging.CRITICAL)
 
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (


### PR DESCRIPTION
The first bucket in a derivative or moving average aggregation may be incomplete, which messes up the metrics. Gather more data before the initial datapoint (one additional metric for derivative since it only depends on the previous point, and `window` metrics for moving average since that's the number of metrics that goes into calculating it), which will then be filtered out when we actually run the query.

This logic is in `adjust_time_range`, which is run in the `post_save` handle for every `ElasticsearchStatusCheck`. 