### PR TITLE
Make navbar collapse earlier to avoid overflow to 2 rows at 720-990px width

### DIFF
--- a/cabot/static/arachnys/css/override-navbar-min-width.css
+++ b/cabot/static/arachnys/css/override-navbar-min-width.css
@@ -1,0 +1,38 @@
+/* change navbar collapse width without using less because we use precompiled bootstrap
+   taken from https://stackoverflow.com/a/36289507 */
+@media (max-width: 992px) {
+    .navbar-header {
+        float: none;
+    }
+    .navbar-left,.navbar-right {
+        float: none !important;
+    }
+    .navbar-toggle {
+        display: block;
+    }
+    .navbar-collapse {
+        border-top: 1px solid transparent;
+        box-shadow: inset 0 1px 0 rgba(255,255,255,0.1);
+    }
+    .navbar-fixed-top {
+        top: 0;
+        border-width: 0 0 1px;
+    }
+    .navbar-collapse.collapse {
+        display: none!important;
+    }
+    .navbar-nav {
+        float: none!important;
+        margin-top: 7.5px;
+    }
+    .navbar-nav>li {
+        float: none;
+    }
+    .navbar-nav>li>a {
+        padding-top: 10px;
+        padding-bottom: 10px;
+    }
+    .collapse.in{
+        display:block !important;
+    }
+}

--- a/cabot/templates/base.html
+++ b/cabot/templates/base.html
@@ -17,6 +17,7 @@
   <link rel="stylesheet" href="{% static "arachnys/css/morris.css" %}" type="text/css">
   <link rel="stylesheet" href="{% static "arachnys/css/graph.css" %}" type="text/css">
   <link rel="stylesheet" href="{% static "arachnys/css/dropdown.css" %}" type="text/css">
+  <link rel="stylesheet" href="{% static "arachnys/css/override-navbar-min-width.css" %}" type="text/css">
   {% endcompress %}
   <link href="//netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.css" rel="stylesheet">
 


### PR DESCRIPTION
Started happening when I added the 'Acks' button...

A better solution would be to override the Bootstrap width variables in less, but we use precompiled bootstrap (i.e. distributed as css files) and I'm not convinced it's worth messing with. :/