### PR TITLE
fix issue with property comparison

### DIFF
--- a/cabot/cabotapp/models.py
+++ b/cabot/cabotapp/models.py
@@ -742,9 +742,7 @@ class ActivityCounter(models.Model):
 
 class HttpStatusCheck(StatusCheck):
 
-    @property
-    def check_category(self):
-        return "HTTP check"
+    check_category = "HTTP check"
 
     @property
     def description(self):
@@ -906,9 +904,7 @@ class HttpStatusCheck(StatusCheck):
 
 class JenkinsStatusCheck(StatusCheck):
 
-    @property
-    def check_category(self):
-        return "Jenkins check"
+    check_category = "Jenkins check"
 
     @property
     def description(self):
@@ -1007,9 +1003,7 @@ class JenkinsStatusCheck(StatusCheck):
 
 class TCPStatusCheck(StatusCheck):
 
-    @property
-    def check_category(self):
-        return "TCP check"
+    check_category = "TCP check"
 
     @property
     def description(self):

--- a/cabot/cabotapp/tests/test_status_check.py
+++ b/cabot/cabotapp/tests/test_status_check.py
@@ -261,7 +261,7 @@ class TestStatusCheck(LocalTestCase):
     def test_run_all(self, mock_run_status_check):
         tasks.run_all_checks()
         mock_run_status_check.assert_has_calls([
-            call.apply_async((10102,), queue='normal_checks'),
+            call.apply_async((10102,), queue='critical_checks'),
             call.apply_async((10101,), queue='normal_checks'),
             call.apply_async((10104,), queue='normal_checks'),
             call.apply_async((10103,), queue='normal_checks'),

--- a/cabot/metricsapp/models/elastic.py
+++ b/cabot/metricsapp/models/elastic.py
@@ -70,6 +70,8 @@ class ElasticsearchStatusCheck(MetricsStatusCheckBase):
     class Meta:
         app_label = 'metricsapp'
 
+    check_category = "Elasticsearch check"
+
     @property
     def description(self):
         desc = []
@@ -78,10 +80,6 @@ class ElasticsearchStatusCheck(MetricsStatusCheckBase):
         if self.high_alert_value is not None:
             desc.append('{}: {} {}'.format(self.high_alert_importance.title(), self.check_type, self.high_alert_value))
         return '; '.join(desc)
-
-    @property
-    def check_category(self):
-        return "Elasticsearch check"
 
     metrics_update_url = 'grafana-es-update'
     refresh_url = 'grafana-es-refresh'


### PR DESCRIPTION
Nothing was being routed to critical queues because we were comparing `check_category` on the instance to `check_category` on the class [here](https://github.com/Affirm/cabot/blob/master/cabot/cabotapp/tasks.py#L53):

```
>>> HttpStatusCheck.check_category
<property object at 0x7f4f53f0c7e0>
>>> b.check_category
'HTTP check'
```